### PR TITLE
Add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "giveaways.json"
   ],
   "scripts": {
-    "test": "node index.js",
+    "start": "node index.js",
     "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\""
   },


### PR DESCRIPTION
**Adding a start script in package.json:**


**Changes:**

- [x] Rename the "test" to "start" so that the bot can automatically get running instead of giving the error of no start scripts.