### PR TITLE
Fix MongoDB wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Here is an example, using quick.db, a Sqlite database. The comments in the code 
 Other examples:
 
 - [MySQL example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/mysql.js)
-- [MongoDB example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/mysql.js)
+- [MongoDB example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/mongodb.js)
 
 ```js
 const Discord = require('discord.js'),


### PR DESCRIPTION
The link redirects to mysql.js instead of mongodb.js