### PR TITLE
✨ Bugfix/quickmongo | Manager starts too early/DB is not fast enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Other examples:
 
 - [MySQL example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/mysql.js)
 - [MongoDB (Mongoose) example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/mongoose.js)
-- [MongoDB (QuickMongo) example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/quickmongo.js)
+- [MongoDB (QuickMongo) example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/quickmongo.js) ⚠️ **Note**: Not recommended for high giveaway usage, use the `mongoose` example instead
 - [Enmap example](https://github.com/Androz2091/discord-giveaways/blob/master/examples/custom-databases/enmap.js)
 
 ```js

--- a/examples/custom-databases/quickmongo.js
+++ b/examples/custom-databases/quickmongo.js
@@ -69,7 +69,7 @@ client.giveawaysManager = manager;
 // DB is ready
 db.on('ready', async () => {
     if (!(await db.get('giveaways'))) await db.set('giveaways', []);
-    // Start the giveawaysMmanager only after the DB got checked to prevent an error
+    // Start the "giveawaysManager" only after the DB got checked to prevent an error
     client.giveawaysManager._init();
 });
 

--- a/examples/custom-databases/quickmongo.js
+++ b/examples/custom-databases/quickmongo.js
@@ -66,8 +66,10 @@ const manager = new GiveawayManagerWithOwnDatabase(client, {
 // We now have a giveawaysManager property to access the manager everywhere!
 client.giveawaysManager = manager;
 
+// DB is ready
 db.on('ready', async () => {
     if (!(await db.get('giveaways'))) await db.set('giveaways', []);
+    // Start the giveawaysMmanager only after the DB got checked to prevent an error
     client.giveawaysManager._init();
 });
 

--- a/examples/custom-databases/quickmongo.js
+++ b/examples/custom-databases/quickmongo.js
@@ -8,9 +8,6 @@ const Discord = require('discord.js'),
 // Load quickmongo
 const { Database } = require('quickmongo');
 const db = new Database('mongodb://localhost/giveaways');
-db.on('ready', async () => {
-    if ((await db.get('giveaways')) === null) await db.set('giveaways', []);
-});
 
 const { GiveawaysManager } = require('discord-giveaways');
 class GiveawayManagerWithOwnDatabase extends GiveawaysManager {
@@ -65,9 +62,14 @@ const manager = new GiveawayManagerWithOwnDatabase(client, {
         embedColor: '#FF0000',
         reaction: '🎉'
     }
-});
+}, false);
 // We now have a giveawaysManager property to access the manager everywhere!
 client.giveawaysManager = manager;
+
+db.on('ready', async () => {
+    if ((await db.get('giveaways')) === null) await db.set('giveaways', []);
+    client.giveawaysManager._init();
+});
 
 client.on('ready', () => {
     console.log('I\'m ready!');

--- a/examples/custom-databases/quickmongo.js
+++ b/examples/custom-databases/quickmongo.js
@@ -67,7 +67,7 @@ const manager = new GiveawayManagerWithOwnDatabase(client, {
 client.giveawaysManager = manager;
 
 db.on('ready', async () => {
-    if ((await db.get('giveaways')) === null) await db.set('giveaways', []);
+    if (!(await db.get('giveaways'))) await db.set('giveaways', []);
     client.giveawaysManager._init();
 });
 

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -72,7 +72,7 @@ exports.defaultGiveawayMessages = {
  *
  * @property {string} [storage='./giveaways.json'] The storage path for the giveaways.
  * @property {number} [updateCountdownEvery=5000] The giveaway update interval (in ms).
- * @property {number} [endedGiveawaysLifetime=0] The time (in ms) after which a ended giveaway should get deleted from the DB. (0 for never)
+ * @property {number} [endedGiveawaysLifetime=null] The time (in ms) after which a ended giveaway should get deleted from the DB. (0 for never)
  * @property {boolean} [hasGuildMembersIntent=false] Whether the client instance has access to the GUILD_MEMBERS intent. If set to true, everything will be faster.
  * @property {string} [DJSlib] The Discord.js library version you want to use
  * @property {GiveawayStartOptions} [default] The default options for new giveaways.

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -92,7 +92,7 @@ exports.GiveawaysManagerOptions = {};
 exports.defaultManagerOptions = {
     storage: './giveaways.json',
     updateCountdownEvery: 5000,
-    endedGiveawaysLifetime: 0,
+    endedGiveawaysLifetime: null,
     hasGuildMemberIntent: false,
     default: {
         botsCanWin: false,

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -285,7 +285,7 @@ class Giveaway extends EventEmitter {
             const message = await this.channel.messages.fetch(this.messageID).catch(() => {});
             if (!message) {
                 this.manager.giveaways = this.manager.giveaways.filter((g) => g.messageID !== this.messageID);
-                this.manager.deleteGiveaway(this.messageID);
+                await this.manager.deleteGiveaway(this.messageID);
                 return reject('Unable to fetch message with ID ' + this.messageID + '.');
             }
             this.message = message;
@@ -401,7 +401,7 @@ class Giveaway extends EventEmitter {
             await this.manager.editGiveaway(this.messageID, this.data);
             if (winners.length > 0) {
                 this.winnerIDs = winners.map((w) => w.id);
-                this.manager.editGiveaway(this.messageID, this.data);
+                await this.manager.editGiveaway(this.messageID, this.data);
                 const embed = this.manager.generateEndEmbed(this, winners);
                 this.message.edit(this.messages.giveawayEnded, { embed }).catch(() => {});
                 const formattedWinners = winners.map((w) => `<@${w.id}>`).join(', ');
@@ -441,7 +441,7 @@ class Giveaway extends EventEmitter {
             const winners = await this.roll(options.winnerCount);
             if (winners.length > 0) {
                 this.winnerIDs = winners.map((w) => w.id);
-                this.manager.editGiveaway(this.messageID, this.data);
+                await this.manager.editGiveaway(this.messageID, this.data);
                 const embed = this.manager.generateEndEmbed(this, winners);
                 this.message.edit(this.messages.giveawayEnded, { embed }).catch(() => {});
                 const formattedWinners = winners.map((w) => '<@' + w.id + '>').join(', ');

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -398,7 +398,7 @@ class Giveaway extends EventEmitter {
                 return reject('Unable to fetch message with ID ' + this.messageID + '.');
             }
             const winners = await this.roll();
-            this.manager.editGiveaway(this.messageID, this.data);
+            await this.manager.editGiveaway(this.messageID, this.data);
             if (winners.length > 0) {
                 this.winnerIDs = winners.map((w) => w.id);
                 this.manager.editGiveaway(this.messageID, this.data);

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -462,7 +462,7 @@ class GiveawaysManager extends EventEmitter {
             const endedGiveaways = this.giveaways.filter(
                 (g) => g.ended && g.endAt + this.options.endedGiveawaysLifetime <= Date.now()
             );
-            for (giveaway of endedGiveaways) {
+            for (const giveaway of endedGiveaways) {
                 await this.deleteGiveaway(giveaway.messageID);
             }
         }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -462,6 +462,9 @@ class GiveawaysManager extends EventEmitter {
             const endedGiveaways = this.giveaways.filter(
                 (g) => g.ended && g.endAt + this.options.endedGiveawaysLifetime <= Date.now()
             );
+            this.giveaways = this.giveaways.filter(
+                (g) => !endedGiveaways.map((giveaway) => giveaway.messageID).includes(g.messageID)
+            );
             for (const giveaway of endedGiveaways) {
                 await this.deleteGiveaway(giveaway.messageID);
             }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -458,7 +458,7 @@ class GiveawaysManager extends EventEmitter {
             if (this.client.readyAt) this._checkGiveaway.call(this);
         }, this.options.updateCountdownEvery);
         this.ready = true;
-        if (!isNaN(this.options.endedGiveawaysLifetime) && this.options.endedGiveawaysLifetime) {
+        if (!isNaN(this.options.endedGiveawaysLifetime) && typeof this.options.endedGiveawaysLifetime === 'number') {
             const endedGiveaways = this.giveaways.filter(
                 (g) => g.ended && g.endAt + this.options.endedGiveawaysLifetime <= Date.now()
             );

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -464,7 +464,7 @@ class GiveawaysManager extends EventEmitter {
         ) {
             this.giveaways
                 .filter((g) => g.ended && ((g.endAt + this.options.endedGiveawaysLifetime) <= Date.now()))
-                .forEach((giveaway) => this.deleteGiveaway(giveaway.messageID));
+                .forEach(async (giveaway) => await this.deleteGiveaway(giveaway.messageID));
         }
 
         this.client.on('raw', (packet) => this._handleRawPacket(packet));

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -458,13 +458,13 @@ class GiveawaysManager extends EventEmitter {
             if (this.client.readyAt) this._checkGiveaway.call(this);
         }, this.options.updateCountdownEvery);
         this.ready = true;
-        if (
-            !isNaN(this.options.endedGiveawaysLifetime) &&
-            this.options.endedGiveawaysLifetime
-        ) {
-            this.giveaways
-                .filter((g) => g.ended && ((g.endAt + this.options.endedGiveawaysLifetime) <= Date.now()))
-                .forEach(async (giveaway) => await this.deleteGiveaway(giveaway.messageID));
+        if (!isNaN(this.options.endedGiveawaysLifetime) && this.options.endedGiveawaysLifetime) {
+            const endedGiveaways = this.giveaways.filter(
+                (g) => g.ended && g.endAt + this.options.endedGiveawaysLifetime <= Date.now()
+            );
+            for (giveaway of endedGiveaways) {
+                await this.deleteGiveaway(giveaway.messageID);
+            }
         }
 
         this.client.on('raw', (packet) => this._handleRawPacket(packet));


### PR DESCRIPTION
Prevents Error
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'forEach' of null
at GiveawayManagerWithOwnDatabase._init (C:\Privat\Coding\Bots\Discord\Bots\giveaways-bot-master\node_modules\discord-giveaways\src\Manager.js:454:22)
```
Because at the very first bootup (or when you delete the whole DB storage) there is nothing in the DB and the `giveawaysManager` starts faster than the `ready` event of the DB gets emitted and so `if ((await db.get('giveaways')) === null) await db.set('giveaways', []);` gets done too late and then manager gets an error because there is nothing in the DB.

Related to and uses solution of #153

If someone knows a better solution, please name it.