### PR TITLE
🐛 Bugfix and improve roll and reroll function

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -123,7 +123,7 @@ exports.defaultRerollOptions = {
     winnerCount: null,
     messages: {
         congrat: ':tada: New winner(s) : {winners}! Congratulations!\n{messageURL}',
-        error: 'No valid participations, no winners can be chosen!'
+        error: 'No valid participations, no new winner(s) can be chosen!'
     }
 };
 

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -331,12 +331,12 @@ class Giveaway extends EventEmitter {
         const winners = [];
 
         for (const u of rolledWinners) {
-            const isValidEntry = !winners.some(winner => winner.id === u.id) && (await this.checkWinnerEntry(u));
+            const isValidEntry = !winners.some((winner) => winner.id === u.id) && (await this.checkWinnerEntry(u));
             if (isValidEntry) winners.push(u);
             else {
                 // find a new winner
                 for (const user of users.array()) {
-                    const isUserValidEntry = !winners.some(winner => winner.id === user.id) && (await this.checkWinnerEntry(user));
+                    const isUserValidEntry = !winners.some((winner) => winner.id === user.id) && (await this.checkWinnerEntry(user));
                     if (!isUserValidEntry) continue;
                     else {
                         winners.push(user);

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -298,6 +298,7 @@ class Giveaway extends EventEmitter {
      * @returns {Promise<boolean>} Whether it is a valid entry
      */
     async checkWinnerEntry(user) {
+        if (this.winnerIDs.includes(user.id)) return false;
         const guild = this.channel.guild;
         const member = guild.member(user.id) || await guild.members.fetch(user.id).catch(() => {});
         if (!member) return false;
@@ -326,7 +327,7 @@ class Giveaway extends EventEmitter {
             .filter((u) => !u.bot || u.bot === this.botsCanWin)
             .filter((u) => u.id !== this.message.client.user.id);
 
-        const rolledWinners = users.random(winnerCount || this.winnerCount);
+        const rolledWinners = users.random(Math.min(winnerCount || this.winnerCount, users.size));
         const winners = [];
 
         for (const u of rolledWinners) {

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -334,11 +334,10 @@ class Giveaway extends EventEmitter {
             const isValidEntry = !winners.some((winner) => winner.id === u.id) && (await this.checkWinnerEntry(u));
             if (isValidEntry) winners.push(u);
             else {
-                // find a new winner
+                // Find a new winner
                 for (const user of users.array()) {
                     const isUserValidEntry = !winners.some((winner) => winner.id === user.id) && (await this.checkWinnerEntry(user));
-                    if (!isUserValidEntry) continue;
-                    else {
+                    if (isUserValidEntry) {
                         winners.push(user);
                         break;
                     }

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -258,7 +258,6 @@ class Giveaway extends EventEmitter {
             endAt: this.endAt,
             ended: this.ended,
             winnerCount: this.winnerCount,
-            winners: this.winnerIDs,
             prize: this.prize,
             messages: this.messages,
             hostedBy: this.options.hostedBy,

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -325,6 +325,7 @@ class Giveaway extends EventEmitter {
         const users = (await reaction.users.fetch())
             .filter((u) => !u.bot || u.bot === this.botsCanWin)
             .filter((u) => u.id !== this.message.client.user.id);
+        if (!users.size) return [];
 
         const rolledWinners = users.random(Math.min(winnerCount || this.winnerCount, users.size));
         const winners = [];

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -331,14 +331,12 @@ class Giveaway extends EventEmitter {
         const winners = [];
 
         for (const u of rolledWinners) {
-            const isValidEntry = await this.checkWinnerEntry(u) && !winners.some((winner) => winner.id === u.id);
+            const isValidEntry = !winners.some(winner => winner.id === u.id) && (await this.checkWinnerEntry(u));
             if (isValidEntry) winners.push(u);
             else {
                 // find a new winner
                 for (const user of users.array()) {
-                    const alreadyRolled = winners.some((winner) => winner.id === user.id);
-                    if (alreadyRolled) continue;
-                    const isUserValidEntry = await this.checkWinnerEntry(user);
+                    const isUserValidEntry = !winners.some(winner => winner.id === user.id) && (await this.checkWinnerEntry(user));
                     if (!isUserValidEntry) continue;
                     else {
                         winners.push(user);

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -225,11 +225,10 @@ class GiveawaysManager extends EventEmitter {
     reroll(messageID, options = {}) {
         return new Promise(async (resolve, reject) => {
             options = merge(defaultRerollOptions, options);
-            const giveawayData = this.giveaways.find((g) => g.messageID === messageID);
-            if (!giveawayData) {
+            const giveaway = this.giveaways.find((g) => g.messageID === messageID);
+            if (!giveaway) {
                 return reject('No giveaway found with ID ' + messageID + '.');
             }
-            const giveaway = new Giveaway(this, giveawayData);
             giveaway
                 .reroll(options)
                 .then((winners) => {


### PR DESCRIPTION
The change will stop allowing the same winner(s) after **the first** (if the `winnerIDs` changes after the reroll and then there is another reroll, the original winners can win again) reroll because why would someone want that? _For rerference, look at #202_
And I optimized the rest of the roll function.
Fixes #199
Fixes "not saving edited giveaway data after reroll"
Thoughts? 