### PR TITLE
✨ Fetch all reaction users

### DIFF
--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -381,7 +381,14 @@ class Giveaway extends EventEmitter {
         const guild = this.channel.guild;
         // Fetch guild members
         if (this.manager.options.hasGuildMembersIntent) await guild.members.fetch();
-        const users = (await reaction.users.fetch())
+
+        // Fetch all reaction users
+        let userCollection = await reaction.users.fetch();
+        while (userCollection.size % 100 === 0) {
+            userCollection = userCollection.concat(await reaction.users.fetch({ after: userCollection.lastKey() }));
+        }
+
+        const users = userCollection
             .filter((u) => !u.bot || u.bot === this.botsCanWin)
             .filter((u) => u.id !== this.message.client.user.id);
         if (!users.size) return [];


### PR DESCRIPTION
Because we currently only fetch the first 100 users, but there could be more and we currently just don't include >100 users who participate = you have 0 chance to win when there are already 100 reactions
and so this also basically limits the number of winners to 99 (1 = bot)

this pr just fetches until there is no user left (= the fetched amount is less than 100 because 100 is the default fetch limit) because a discord user collection is sorted by id, so we can just use the `after` option to fetch more users
idk if this works fine tho, since where should I get the reactions, but I think it should? 😆

and because of rate limiting, most giveaways should stay under a couple of hundred reactions (<10 fetches), so it should not get limited right? / is there any proper way to deal with it in the case of occurring?