### PR TITLE
🐛 Better JSON file formatting

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -313,7 +313,7 @@ class GiveawaysManager extends EventEmitter {
     async deleteGiveaway(messageID) {
         await writeFileAsync(
             this.options.storage,
-            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data)),
+            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data), null, '\t'),
             'utf-8'
         );
         this.refreshStorage();
@@ -371,7 +371,7 @@ class GiveawaysManager extends EventEmitter {
     async editGiveaway(_messageID, _giveawayData) {
         await writeFileAsync(
             this.options.storage,
-            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data)),
+            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data), null, '\t'),
             'utf-8'
         );
         this.refreshStorage();
@@ -387,7 +387,7 @@ class GiveawaysManager extends EventEmitter {
     async saveGiveaway(messageID, giveawayData) {
         await writeFileAsync(
             this.options.storage,
-            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data)),
+            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data), null, '\t'),
             'utf-8'
         );
         this.refreshStorage();


### PR DESCRIPTION
This PR makes a small change that ensures that JSON files get formatted in a better human-readable way.

Currently, everything is in one line like:
```diff
-  [{...},{...},{...},{...},{...},{...},{...},{...},{...},{...},{...},{...},{...},{...}]
```

With this PR, the file gets properly formatted, like:
```json
[
	{
		"values": "go here"
	},
	{
		"values": "go here"
	},	
	{
		"values": "go here"
	},	
	{
		"values": "go here"
	},
]
```