### PR TITLE
Revert "🐛 Better JSON file formatting"

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -313,7 +313,7 @@ class GiveawaysManager extends EventEmitter {
     async deleteGiveaway(messageID) {
         await writeFileAsync(
             this.options.storage,
-            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data), null, '\t'),
+            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data)),
             'utf-8'
         );
         this.refreshStorage();
@@ -371,7 +371,7 @@ class GiveawaysManager extends EventEmitter {
     async editGiveaway(_messageID, _giveawayData) {
         await writeFileAsync(
             this.options.storage,
-            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data), null, '\t'),
+            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data)),
             'utf-8'
         );
         this.refreshStorage();
@@ -387,7 +387,7 @@ class GiveawaysManager extends EventEmitter {
     async saveGiveaway(messageID, giveawayData) {
         await writeFileAsync(
             this.options.storage,
-            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data), null, '\t'),
+            JSON.stringify(this.giveaways.map((giveaway) => giveaway.data)),
             'utf-8'
         );
         this.refreshStorage();


### PR DESCRIPTION
Reverts Androz2091/discord-giveaways#273
Because formatting the objects will increase the size of the file.
For me: 3 giveaways without = 2,83KB, with = 3,3

If it should get viewed formatted I would recommend copying the content of the file and using a code formatter or some other tool to format it for viewing