### PR TITLE
🐛 fix: typings for deleteGiveaway and delete

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -308,7 +308,7 @@ class GiveawaysManager extends EventEmitter {
     /**
      * Delete a giveaway from the database
      * @param {Discord.Snowflake} messageID The message ID of the giveaway to delete
-     * @returns {Promise<void>}
+     * @returns {Promise<boolean>}
      */
     async deleteGiveaway(messageID) {
         await writeFileAsync(
@@ -317,7 +317,8 @@ class GiveawaysManager extends EventEmitter {
             'utf-8'
         );
         this.refreshStorage();
-        return;
+
+        return true;
     }
 
     /**
@@ -429,7 +430,7 @@ class GiveawaysManager extends EventEmitter {
 
     /**
      * @ignore
-     * @param {any} packet 
+     * @param {any} packet
      */
     async _handleRawPacket(packet) {
         if (!['MESSAGE_REACTION_ADD', 'MESSAGE_REACTION_REMOVE'].includes(packet.t)) return;
@@ -514,7 +515,7 @@ class GiveawaysManager extends EventEmitter {
  * @param {Discord.MessageReaction} reaction The reaction to enter the giveaway
  *
  * @example
- * // This can be used to add features like removing reactions of members when they do not have a specific role (such as giveaway requirements). Best used with the `exemptMembers` property of the giveaways. 
+ * // This can be used to add features like removing reactions of members when they do not have a specific role (such as giveaway requirements). Best used with the `exemptMembers` property of the giveaways.
  * manager.on('giveawayReactionAdded', (giveaway, member, reaction) => {
  *     if (!member.roles.cache.get('123456789')) {
  *          reaction.users.remove(member.user);

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -283,7 +283,7 @@ class GiveawaysManager extends EventEmitter {
      * Deletes a giveaway. It will delete the message and all the giveaway data.
      * @param {Discord.Snowflake} messageID  The message ID of the giveaway
      * @param {boolean} [doNotDeleteMessage=false] Whether the giveaway message shouldn't be deleted
-     * @returns {Promise<void>}
+     * @returns {Promise<boolean>}
      */
     delete(messageID, doNotDeleteMessage = false) {
         return new Promise(async (resolve, reject) => {
@@ -301,7 +301,7 @@ class GiveawaysManager extends EventEmitter {
             this.giveaways = this.giveaways.filter((g) => g.messageID !== messageID);
             await this.deleteGiveaway(messageID);
             this.emit('giveawayDeleted', giveaway);
-            resolve();
+            resolve(true);
         });
     }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,8 +23,7 @@ declare module 'discord-giveaways' {
         public ready: boolean;
 
         public delete(messageID: Snowflake, doNotDeleteMessage?: boolean): Promise<void>;
-        // @ts-ignore-next-line
-        public async deleteGiveaway(messageID: Snowflake): Promise<void>;
+        public deleteGiveaway(messageID: Snowflake): Promise<boolean>;
         public edit(messageID: Snowflake, options: GiveawayEditOptions): Promise<Giveaway>;
         public end(messageID: Snowflake): Promise<GuildMember[]>;
         public reroll(messageID: Snowflake, options?: GiveawayRerollOptions): Promise<GuildMember[]>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,7 @@ declare module 'discord-giveaways' {
         public options: GiveawaysManagerOptions;
         public ready: boolean;
 
-        public delete(messageID: Snowflake, doNotDeleteMessage?: boolean): Promise<void>;
+        public delete(messageID: Snowflake, doNotDeleteMessage?: boolean): Promise<boolean>;
         public deleteGiveaway(messageID: Snowflake): Promise<boolean>;
         public edit(messageID: Snowflake, options: GiveawayEditOptions): Promise<Giveaway>;
         public end(messageID: Snowflake): Promise<GuildMember[]>;


### PR DESCRIPTION
* Minor: Return `boolean` instead of `void` 

This change was made because in the examples it says "Don't forget to return something" and to make TS happy 😅 