### PR TITLE
Make an option to assign updateCountdownEvery to zero

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -418,7 +418,7 @@ class GiveawaysManager extends EventEmitter {
             if (giveaway.remainingTime < this.options.updateCountdownEvery) {
                 setTimeout(() => this.end.call(this, giveaway.messageID), giveaway.remainingTime);
             }
-            if (giveaway.lastChance.enabled && (giveaway.remainingTime - giveaway.lastChance.threshold) < this.options.updateCountdownEvery) {
+            if (giveaway.lastChance.enabled && (giveaway.remainingTime - giveaway.lastChance.threshold) < this.options.updateCountdownEvery > 0) {
                 setTimeout(() => {
                     const embed = this.generateMainEmbed(giveaway, true);
                     giveaway.message.edit(giveaway.messages.giveaway, { embed }).catch(() => {});


### PR DESCRIPTION
When user's using the timestamp formatting that was introduced by Discord last month, users don't want the embeds to get edited, but looking on the current code it shows that if we don't mention the option `updateCountdownEvery` still it will take the default values and update it every 5 seconds, so I am suggesting this change that will allow user to set the value to 0 so that when the value of that field is zero it won't edit the embed.