### PR TITLE
fix - allow discord.js color strings in GiveawayStartOptions#embedColor

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 
 const validateEmbedColor = (embedColor) => {
     try {
-        Discord.Util.resolveColor(embedColor);
+        embedColor = Discord.Util.resolveColor(embedColor);
         return (!isNaN(embedColor) && typeof embedColor === 'number' ? true : false);
     } catch {
         return false;


### PR DESCRIPTION
Solve bug of #378

<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->
This pr change validateEmbedColor method from util.js file to support string embed color type like "GREEN".
## Status

- [x] These changes have been tested ~~and formatted~~ properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.