### PR TITLE
Fix embedColor: hex & [255, 0, 255] = undefined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,8 @@ const Discord = require('discord.js');
 
 const validateEmbedColor = (embedColor) => {
     try {
-        Discord.Util.resolveColor(embedColor);
-        if (!isNaN(embedColor) && typeof embedColor === 'number') return true;
+        var embedColorNum = Discord.Util.resolveColor(embedColor);
+        if (!isNaN(embedColorNum) && typeof embedColorNum === 'number') return true;
         else return false;
     } catch {
         return false;


### PR DESCRIPTION
Discord.Util.resolveColor needs to be saved on a variable, otherwise you check like a hex string
example:
```js
let color = "#ffee33";
Discord.Util.resolveColor(color);
console.log(color) //"#ffee33";
```
BUT:
```js
let color = "#ffee33";
color = Discord.Util.resolveColor(color);
console.log(color) //16772659;
```

https://cdn.discordapp.com/attachments/877178666046599200/909884987996782593/unknown.png

<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->

## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.