### PR TITLE
✏️Use array fill instead of looping over the entries

### DIFF
--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -471,7 +471,7 @@ class Giveaway extends EventEmitter {
                 const highestBonusEntries = await this.checkBonusEntries(user);
                 if (!highestBonusEntries) continue;
                 
-                userArray = userArray.concat(Array(highestBonusEntries).fill(user));
+                userArray.push(...Array(highestBonusEntries).fill(user))
             }
         }
 

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -470,8 +470,8 @@ class Giveaway extends EventEmitter {
 
                 const highestBonusEntries = await this.checkBonusEntries(user);
                 if (!highestBonusEntries) continue;
-
-                for (let i = 0; i < highestBonusEntries; i++) userArray.push(user);
+                
+                userArray = userArray.concat(Array(highestBonusEntries).fill(user))
             }
         }
 

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -471,7 +471,7 @@ class Giveaway extends EventEmitter {
                 const highestBonusEntries = await this.checkBonusEntries(user);
                 if (!highestBonusEntries) continue;
                 
-                userArray = userArray.concat(Array(highestBonusEntries).fill(user))
+                userArray = userArray.concat(Array(highestBonusEntries).fill(user));
             }
         }
 


### PR DESCRIPTION
## Changes
This pr uses the js Array and Array fill method to multiple the user x many times instead of looping over the array.
The purpose of this pr is to solve the heap errors if the number is VERY LARGE thrown by node.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.