### PR TITLE
code refactored and bug fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+        "source.fixAll.eslint": true
     },
     "eslint.validate": ["javascript"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
     },
-    "eslint.validate": ["javascript"]
+    "eslint.validate": ["javascript"],
 }

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -620,7 +620,7 @@ class Giveaway extends EventEmitter {
 
                 if (message?.length > 2000) {
                     channel.send({
-                        content: winMessage.substr(0, winMessage.indexOf('{winners}')),
+                        content: winMessage.slice(0, winMessage.indexOf('{winners}')),
                         allowedMentions: this.allowedMentions,
                         reply: {
                             messageReference:
@@ -632,16 +632,16 @@ class Giveaway extends EventEmitter {
                     });
                     while (formattedWinners.length >= 2000) {
                         await channel.send({
-                            content: formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
+                            content: formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
                             allowedMentions: this.allowedMentions
                         });
                         formattedWinners = formattedWinners.slice(
-                            formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
+                            formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
                         );
                     }
                     channel.send({ content: formattedWinners, allowedMentions: this.allowedMentions });
                     channel.send({
-                        content: winMessage.substr(winMessage.indexOf('{winners}') + 9),
+                        content: winMessage.slice(winMessage.indexOf('{winners}') + 9),
                         allowedMentions: this.allowedMentions
                     });
                 }
@@ -669,7 +669,7 @@ class Giveaway extends EventEmitter {
                             content: message?.length <= 2000 ? message : null,
                             embeds: [
                                 new Discord.MessageEmbed(embed).setDescription(
-                                    embed.description.substr(0, embed.description.indexOf('{winners}'))
+                                    embed.description.slice(0, embed.description.indexOf('{winners}'))
                                 )
                             ],
                             allowedMentions: this.allowedMentions,
@@ -687,13 +687,13 @@ class Giveaway extends EventEmitter {
                             await channel.send({
                                 embeds: [
                                     tempEmbed.setDescription(
-                                        formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 4095)) + ','
+                                        formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095)) + ','
                                     )
                                 ],
                                 allowedMentions: this.allowedMentions
                             });
                             formattedWinners = formattedWinners.slice(
-                                formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 4095) + 2).length
+                                formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095) + 2).length
                             );
                         }
                         channel.send({
@@ -703,7 +703,7 @@ class Giveaway extends EventEmitter {
                         channel.send({
                             embeds: [
                                 tempEmbed.setDescription(
-                                    embed.description.substr(embed.description.indexOf('{winners}') + 9)
+                                    embed.description.slice(embed.description.indexOf('{winners}') + 9)
                                 )
                             ],
                             allowedMentions: this.allowedMentions
@@ -792,7 +792,7 @@ class Giveaway extends EventEmitter {
 
                 if (message?.length > 2000) {
                     channel.send({
-                        content: congratMessage.substr(0, congratMessage.indexOf('{winners}')),
+                        content: congratMessage.slice(0, congratMessage.indexOf('{winners}')),
                         allowedMentions: this.allowedMentions,
                         reply: {
                             messageReference:
@@ -804,16 +804,16 @@ class Giveaway extends EventEmitter {
                     });
                     while (formattedWinners.length >= 2000) {
                         await channel.send({
-                            content: formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
+                            content: formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
                             allowedMentions: this.allowedMentions
                         });
                         formattedWinners = formattedWinners.slice(
-                            formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
+                            formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
                         );
                     }
                     channel.send({ content: formattedWinners, allowedMentions: this.allowedMentions });
                     channel.send({
-                        content: congratMessage.substr(congratMessage.indexOf('{winners}') + 9),
+                        content: congratMessage.slice(congratMessage.indexOf('{winners}') + 9),
                         allowedMentions: this.allowedMentions
                     });
                 }
@@ -841,7 +841,7 @@ class Giveaway extends EventEmitter {
                             content: message?.length <= 2000 ? message : null,
                             embeds: [
                                 new Discord.MessageEmbed(embed).setDescription(
-                                    embed.description.substr(0, embed.description.indexOf('{winners}'))
+                                    embed.description.slice(0, embed.description.indexOf('{winners}'))
                                 )
                             ],
                             allowedMentions: this.allowedMentions,
@@ -859,13 +859,13 @@ class Giveaway extends EventEmitter {
                             await channel.send({
                                 embeds: [
                                     tempEmbed.setDescription(
-                                        formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 4095)) + ','
+                                        formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095)) + ','
                                     )
                                 ],
                                 allowedMentions: this.allowedMentions
                             });
                             formattedWinners = formattedWinners.slice(
-                                formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 4095) + 2).length
+                                formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095) + 2).length
                             );
                         }
                         channel.send({
@@ -875,7 +875,7 @@ class Giveaway extends EventEmitter {
                         channel.send({
                             embeds: [
                                 tempEmbed.setDescription(
-                                    embed.description.substr(embed.description.indexOf('{winners}') + 9)
+                                    embed.description.slice(embed.description.indexOf('{winners}') + 9)
                                 )
                             ],
                             allowedMentions: this.allowedMentions

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -378,12 +378,18 @@ class Giveaway extends EventEmitter {
             if (!this.messageId) return;
             let tryLater = false;
             const channel = await this.client.channels.fetch(this.channelId).catch((err) => {
-                if (err.httpStatus.toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000)
+                // prettier-ignore
+                if ((err.httpStatus).toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000) {
                     tryLater = true;
+                }
             });
             const message = await channel?.messages.fetch(this.messageId).catch((err) => {
-                if (err.httpStatus.toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000)
-                    tryLater = true;
+                // prettier-ignore
+                {
+                    if ((err.httpStatus).toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000) {
+                        tryLater = true;
+                    }
+                }
             });
             if (!message) {
                 if (!tryLater) {

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -189,7 +189,9 @@ class Giveaway extends EventEmitter {
      * @type {Boolean}
      */
     get botsCanWin() {
-        return typeof this.options.botsCanWin === 'boolean' ? this.options.botsCanWin : this.manager.options.default.botsCanWin;
+        return typeof this.options.botsCanWin === 'boolean'
+            ? this.options.botsCanWin
+            : this.manager.options.default.botsCanWin;
     }
 
     /**
@@ -239,7 +241,8 @@ class Giveaway extends EventEmitter {
      */
     get exemptMembersFunction() {
         return this.options.exemptMembers
-            ? (typeof this.options.exemptMembers === 'string' && this.options.exemptMembers.includes('function anonymous'))
+            ? typeof this.options.exemptMembers === 'string' &&
+              this.options.exemptMembers.includes('function anonymous')
                 ? eval(`(${this.options.exemptMembers})`)
                 : eval(this.options.exemptMembers)
             : null;
@@ -256,7 +259,9 @@ class Giveaway extends EventEmitter {
                 const result = await this.exemptMembersFunction(member);
                 return result;
             } catch (err) {
-                console.error(`Giveaway message Id: ${this.messageId}\n${serialize(this.exemptMembersFunction)}\n${err}`);
+                console.error(
+                    `Giveaway message Id: ${this.messageId}\n${serialize(this.exemptMembersFunction)}\n${err}`
+                );
                 return false;
             }
         }
@@ -288,11 +293,11 @@ class Giveaway extends EventEmitter {
             botsCanWin: this.options.botsCanWin,
             exemptPermissions: this.options.exemptPermissions,
             exemptMembers:
-                (!this.options.exemptMembers || typeof this.options.exemptMembers === 'string')
+                !this.options.exemptMembers || typeof this.options.exemptMembers === 'string'
                     ? this.options.exemptMembers || undefined
                     : serialize(this.options.exemptMembers),
             bonusEntries:
-                (!this.options.bonusEntries || typeof this.options.bonusEntries === 'string')
+                !this.options.bonusEntries || typeof this.options.bonusEntries === 'string'
                     ? this.options.bonusEntries || undefined
                     : serialize(this.options.bonusEntries),
             reaction: this.options.reaction,
@@ -310,10 +315,13 @@ class Giveaway extends EventEmitter {
      * if it will end soon
      * @returns {NodeJS.Timeout}
      */
-    ensureEndTimeout () {
+    ensureEndTimeout() {
         if (this.endTimeout) return;
         if (this.remainingTime > (this.manager.options.forceUpdateEvery || DEFAULT_CHECK_INTERVAL)) return;
-        this.endTimeout = setTimeout(() => this.manager.end.call(this.manager, this.messageId).catch(() => {}), this.remainingTime);
+        this.endTimeout = setTimeout(
+            () => this.manager.end.call(this.manager, this.messageId).catch(() => {}),
+            this.remainingTime
+        );
     }
 
     /**
@@ -370,17 +378,21 @@ class Giveaway extends EventEmitter {
             if (!this.messageId) return;
             let tryLater = false;
             const channel = await this.client.channels.fetch(this.channelId).catch((err) => {
-                if ((err.httpStatus).toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000) tryLater = true;
+                if (err.httpStatus.toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000)
+                    tryLater = true;
             });
             const message = await channel?.messages.fetch(this.messageId).catch((err) => {
-                if ((err.httpStatus).toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000) tryLater = true;
+                if (err.httpStatus.toString().startsWith('5') || err.httpStatus === 429 || err.code === 130000)
+                    tryLater = true;
             });
             if (!message) {
                 if (!tryLater) {
                     this.manager.giveaways = this.manager.giveaways.filter((g) => g.messageId !== this.messageId);
                     await this.manager.deleteGiveaway(this.messageId);
                 }
-                return reject('Unable to fetch message with Id ' + this.messageId + '.' + tryLater ? ' Try later!' : '');
+                return reject(
+                    'Unable to fetch message with Id ' + this.messageId + '.' + (tryLater ? ' Try later!' : '')
+                );
             }
             resolve(message);
         });
@@ -440,11 +452,14 @@ class Giveaway extends EventEmitter {
         if (!this.message) return [];
         // Pick the winner
         const emoji = Discord.Util.resolvePartialEmoji(this.reaction);
-        const reaction = this.message.reactions.cache.find((r) => [r.emoji.name, r.emoji.id].filter(Boolean).includes(emoji?.name ?? emoji?.id));
+        const reaction = this.message.reactions.cache.find((r) =>
+            [r.emoji.name, r.emoji.id].filter(Boolean).includes(emoji?.name ?? emoji?.id)
+        );
         if (!reaction) return [];
         const guild = this.message.guild;
         // Fetch guild members
-        if (new Discord.Intents(this.client.options.intents).has(Discord.Intents.FLAGS.GUILD_MEMBERS)) await guild.members.fetch();
+        if (new Discord.Intents(this.client.options.intents).has(Discord.Intents.FLAGS.GUILD_MEMBERS))
+            await guild.members.fetch();
 
         // Fetch all reaction users
         let userCollection = await reaction.users.fetch().catch(() => {});
@@ -482,9 +497,12 @@ class Giveaway extends EventEmitter {
              * Random mechanism like https://github.com/discordjs/collection/blob/master/src/index.ts
              * because collections/maps do not allow duplicates and so we cannot use their built in "random" function
              */
-            rolledWinners = Array.from({
-                length: Math.min(winnerCount, users.size)
-            }, () => userArray.splice(Math.floor(Math.random() * userArray.length), 1)[0]);
+            rolledWinners = Array.from(
+                {
+                    length: Math.min(winnerCount, users.size)
+                },
+                () => userArray.splice(Math.floor(Math.random() * userArray.length), 1)[0]
+            );
         }
 
         const winners = [];
@@ -495,7 +513,8 @@ class Giveaway extends EventEmitter {
             else {
                 // Find a new winner
                 for (const user of userArray || [...users.values()]) {
-                    const isUserValidEntry = !winners.some((winner) => winner.id === user.id) && (await this.checkWinnerEntry(user));
+                    const isUserValidEntry =
+                        !winners.some((winner) => winner.id === user.id) && (await this.checkWinnerEntry(user));
                     if (isUserValidEntry) {
                         winners.push(user);
                         break;
@@ -519,20 +538,24 @@ class Giveaway extends EventEmitter {
             if (!this.message) return reject('Unable to fetch message with Id ' + this.messageId + '.');
 
             // Update data
-            if (options.newMessages && typeof options.newMessages === 'object') this.messages = merge(this.messages, options.newMessages);
+            if (options.newMessages && typeof options.newMessages === 'object')
+                this.messages = merge(this.messages, options.newMessages);
             if (typeof options.newThumbnail === 'string') this.thumbnail = options.newThumbnail;
             if (typeof options.newPrize === 'string') this.prize = options.newPrize;
             if (options.newExtraData) this.extraData = options.newExtraData;
 
-            if (Number.isInteger(options.newWinnerCount) && options.newWinnerCount > 0 && !this.isDrop) this.winnerCount = options.newWinnerCount;
-            if (!isNaN(options.addTime) && typeof options.addTime === 'number' && !this.isDrop) {
+            if (Number.isInteger(options.newWinnerCount) && options.newWinnerCount > 0 && !this.isDrop)
+                this.winnerCount = options.newWinnerCount;
+            if (Number.isFinite(options.addTime) && !this.isDrop) {
                 this.endAt = this.endAt + options.addTime;
                 if (this.endTimeout) clearTimeout(this.endTimeout);
                 this.ensureEndTimeout();
             }
-            if (!isNaN(options.setEndTimestamp) && typeof options.setEndTimestamp === 'number' && !this.isDrop) this.endAt = options.setEndTimestamp;
-            if (Array.isArray(options.newBonusEntries) && !this.isDrop) this.options.bonusEntries = options.newBonusEntries.filter((elem) => typeof elem === 'object');
-            if (options.newLastChance && typeof options.newLastChance === 'object' && !this.isDrop) this.options.lastChance = merge(this.options.lastChance || {}, options.newLastChance);
+            if (Number.isFinite(options.setEndTimestamp) && !this.isDrop) this.endAt = options.setEndTimestamp;
+            if (Array.isArray(options.newBonusEntries) && !this.isDrop)
+                this.options.bonusEntries = options.newBonusEntries.filter((elem) => typeof elem === 'object');
+            if (options.newLastChance && typeof options.newLastChance === 'object' && !this.isDrop)
+                this.options.lastChance = merge(this.options.lastChance || {}, options.newLastChance);
 
             await this.manager.editGiveaway(this.messageId, this.data);
             if (this.remainingTime <= 0) this.manager.end(this.messageId).catch(() => {});
@@ -559,13 +582,15 @@ class Giveaway extends EventEmitter {
         return new Promise(async (resolve, reject) => {
             if (this.ended) return reject('Giveaway with message Id ' + this.messageId + ' is already ended');
             this.ended = true;
-            this.message ??= await this.fetchMessage().catch((err) => (err.includes('Try later!') ? (this.ended = false) : undefined));
+            this.message ??= await this.fetchMessage().catch((err) =>
+                err.includes('Try later!') ? (this.ended = false) : undefined
+            );
             if (!this.message) return reject('Unable to fetch message with Id ' + this.messageId + '.');
 
             if (this.isDrop || this.endAt < this.client.readyTimestamp) this.endAt = Date.now();
             await this.manager.editGiveaway(this.messageId, this.data);
             const winners = await this.roll();
-            
+
             const channel =
                 this.message.channel.isThread() && !this.message.channel.sendable
                     ? this.message.channel.parent
@@ -586,13 +611,16 @@ class Giveaway extends EventEmitter {
                 let formattedWinners = winners.map((w) => `<@${w.id}>`).join(', ');
                 const winMessage = this.fillInString(this.messages.winMessage.content || this.messages.winMessage);
                 const message = winMessage?.replace('{winners}', formattedWinners);
-                
+
                 if (message?.length > 2000) {
                     channel.send({
                         content: winMessage.substr(0, winMessage.indexOf('{winners}')),
                         allowedMentions: this.allowedMentions,
                         reply: {
-                            messageReference: typeof this.messages.winMessage.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                            messageReference:
+                                typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                    ? this.messageId
+                                    : undefined,
                             failIfNotExists: false
                         }
                     });
@@ -601,7 +629,9 @@ class Giveaway extends EventEmitter {
                             content: formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
                             allowedMentions: this.allowedMentions
                         });
-                        formattedWinners = formattedWinners.slice(formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999) + 2).length);
+                        formattedWinners = formattedWinners.slice(
+                            formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
+                        );
                     }
                     channel.send({ content: formattedWinners, allowedMentions: this.allowedMentions });
                     channel.send({
@@ -621,7 +651,8 @@ class Giveaway extends EventEmitter {
                             allowedMentions: this.allowedMentions,
                             reply: {
                                 messageReference:
-                                    message?.length <= 2000 && typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                    message?.length <= 2000 &&
+                                    typeof this.messages.winMessage.replyToGiveaway === 'boolean'
                                         ? this.messageId
                                         : undefined,
                                 failIfNotExists: false
@@ -638,7 +669,8 @@ class Giveaway extends EventEmitter {
                             allowedMentions: this.allowedMentions,
                             reply: {
                                 messageReference:
-                                    message?.length <= 2000 && typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                    message?.length <= 2000 &&
+                                    typeof this.messages.winMessage.replyToGiveaway === 'boolean'
                                         ? this.messageId
                                         : undefined,
                                 failIfNotExists: false
@@ -676,7 +708,10 @@ class Giveaway extends EventEmitter {
                         content: message,
                         allowedMentions: this.allowedMentions,
                         reply: {
-                            messageReference: typeof this.messages.winMessage.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                            messageReference:
+                                typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                    ? this.messageId
+                                    : undefined,
                             failIfNotExists: false
                         }
                     });
@@ -691,7 +726,8 @@ class Giveaway extends EventEmitter {
                         embeds: embed ? [embed] : null,
                         allowedMentions: this.allowedMentions,
                         reply: {
-                            messageReference: typeof noWinnerMessage?.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                            messageReference:
+                                typeof noWinnerMessage?.replyToGiveaway === 'boolean' ? this.messageId : undefined,
                             failIfNotExists: false
                         }
                     });
@@ -725,7 +761,7 @@ class Giveaway extends EventEmitter {
             if (options.winnerCount && (!Number.isInteger(options.winnerCount) || options.winnerCount < 1)) {
                 return reject(`options.winnerCount is not a positive integer. (val=${options.winnerCount})`);
             }
-            
+
             const winners = await this.roll(options.winnerCount || undefined);
             const channel =
                 this.message.channel.isThread() && !this.message.channel.sendable
@@ -753,7 +789,10 @@ class Giveaway extends EventEmitter {
                         content: congratMessage.substr(0, congratMessage.indexOf('{winners}')),
                         allowedMentions: this.allowedMentions,
                         reply: {
-                            messageReference: typeof options.messages.congrat.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                            messageReference:
+                                typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                    ? this.messageId
+                                    : undefined,
                             failIfNotExists: false
                         }
                     });
@@ -762,7 +801,9 @@ class Giveaway extends EventEmitter {
                             content: formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
                             allowedMentions: this.allowedMentions
                         });
-                        formattedWinners = formattedWinners.slice(formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999) + 2).length);
+                        formattedWinners = formattedWinners.slice(
+                            formattedWinners.substr(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
+                        );
                     }
                     channel.send({ content: formattedWinners, allowedMentions: this.allowedMentions });
                     channel.send({
@@ -782,7 +823,8 @@ class Giveaway extends EventEmitter {
                             allowedMentions: this.allowedMentions,
                             reply: {
                                 messageReference:
-                                    message?.length <= 2000 && typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                    message?.length <= 2000 &&
+                                    typeof options.messages.congrat.replyToGiveaway === 'boolean'
                                         ? this.messageId
                                         : undefined,
                                 failIfNotExists: false
@@ -799,7 +841,8 @@ class Giveaway extends EventEmitter {
                             allowedMentions: this.allowedMentions,
                             reply: {
                                 messageReference:
-                                    message?.length <= 2000 && typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                    message?.length <= 2000 &&
+                                    typeof options.messages.congrat.replyToGiveaway === 'boolean'
                                         ? this.messageId
                                         : undefined,
                                 failIfNotExists: false
@@ -837,7 +880,10 @@ class Giveaway extends EventEmitter {
                         content: message,
                         allowedMentions: this.allowedMentions,
                         reply: {
-                            messageReference: typeof options.messages.congrat.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                            messageReference:
+                                typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                    ? this.messageId
+                                    : undefined,
                             failIfNotExists: false
                         }
                     });
@@ -850,7 +896,8 @@ class Giveaway extends EventEmitter {
                     embeds: embed ? [embed] : null,
                     allowedMentions: this.allowedMentions,
                     reply: {
-                        messageReference: typeof options.messages.error.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                        messageReference:
+                            typeof options.messages.error.replyToGiveaway === 'boolean' ? this.messageId : undefined,
                         failIfNotExists: false
                     }
                 });
@@ -869,14 +916,15 @@ class Giveaway extends EventEmitter {
             if (this.ended) return reject('Giveaway with message Id ' + this.messageId + ' is already ended.');
             this.message ??= await this.fetchMessage().catch(() => {});
             if (!this.message) return reject('Unable to fetch message with Id ' + this.messageId + '.');
-            if (this.pauseOptions.isPaused) return reject('Giveaway with message Id ' + this.messageId + ' is already paused.');
+            if (this.pauseOptions.isPaused)
+                return reject('Giveaway with message Id ' + this.messageId + ' is already paused.');
             if (this.isDrop) return reject('Drop giveaways cannot get paused!');
             if (this.endTimeout) clearTimeout(this.endTimeout);
 
             // Update data
             const pauseOptions = this.options.pauseOptions || {};
             if (typeof options.content === 'string') pauseOptions.content = options.content;
-            if (!isNaN(options.unPauseAfter) && options.unPauseAfter === 'number') {
+            if (Number.isFinite(options.unPauseAfter)) {
                 if (options.unPauseAfter < Date.now()) {
                     pauseOptions.unPauseAfter = Date.now() + options.unPauseAfter;
                     this.endAt = this.endAt + options.unPauseAfter;
@@ -916,11 +964,12 @@ class Giveaway extends EventEmitter {
             if (this.ended) return reject('Giveaway with message Id ' + this.messageId + ' is already ended.');
             this.message ??= await this.fetchMessage().catch(() => {});
             if (!this.message) return reject('Unable to fetch message with Id ' + this.messageId + '.');
-            if (!this.pauseOptions.isPaused) return reject('Giveaway with message Id ' + this.messageId + ' is not paused.');
+            if (!this.pauseOptions.isPaused)
+                return reject('Giveaway with message Id ' + this.messageId + ' is not paused.');
             if (this.isDrop) return reject('Drop giveaways cannot get unpaused!');
 
             // Update data
-            if (!isNaN(this.pauseOptions.durationAfterPause) && typeof this.pauseOptions.durationAfterPause === 'number') {
+            if (Number.isFinite(this.pauseOptions.durationAfterPause)) {
                 this.endAt = Date.now() + this.pauseOptions.durationAfterPause;
             }
             this.options.pauseOptions.isPaused = false;

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -570,16 +570,19 @@ class GiveawaysManager extends EventEmitter {
                 }, giveaway.remainingTime - giveaway.lastChance.threshold);
             }
 
-            // Regular case: the giveaway is not ended and we need to update it
+            // Fetch the message if necessary and make sure the embed is alright
             giveaway.message ??= await giveaway.fetchMessage().catch(() => {});
             if (!giveaway.message) return;
+            if (!giveaway.message.embeds[0]) {
+                giveaway.message = await giveaway.message.suppressEmbeds(false).catch(() => {});
+            }
+
+            // Regular case: the giveaway is not ended and we need to update it
             const lastChanceEnabled =
                 giveaway.lastChance.enabled && giveaway.remainingTime < giveaway.lastChance.threshold;
-            const oldEmbed = giveaway.message.embeds[0];
             const updatedEmbed = this.generateMainEmbed(giveaway, lastChanceEnabled);
             const needUpdate =
-                !oldEmbed ||
-                !updatedEmbed.equals(oldEmbed) ||
+                !updatedEmbed.equals(giveaway.message.embeds[0]) ||
                 giveaway.message.content !== giveaway.fillInString(giveaway.messages.giveaway);
 
             if (needUpdate || this.options.forceUpdateEvery) {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -15,7 +15,7 @@ const {
     DEFAULT_CHECK_INTERVAL
 } = require('./Constants.js');
 const Giveaway = require('./Giveaway.js');
-const { validateEmbedColor, embedEqual } = require('./utils.js');
+const { validateEmbedColor } = require('./utils.js');
 
 /**
  * Giveaways Manager
@@ -575,9 +575,11 @@ class GiveawaysManager extends EventEmitter {
             if (!giveaway.message) return;
             const lastChanceEnabled =
                 giveaway.lastChance.enabled && giveaway.remainingTime < giveaway.lastChance.threshold;
+            const oldEmbed = giveaway.message.embeds[0];
             const updatedEmbed = this.generateMainEmbed(giveaway, lastChanceEnabled);
             const needUpdate =
-                !embedEqual(giveaway.message.embeds[0], updatedEmbed) ||
+                !oldEmbed ||
+                !updatedEmbed.equals(oldEmbed) ||
                 giveaway.message.content !== giveaway.fillInString(giveaway.messages.giveaway);
 
             if (needUpdate || this.options.forceUpdateEvery) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,27 +9,6 @@ const validateEmbedColor = (embedColor) => {
     }
 };
 
-const embedEqual = (embed1, embed2) => {
-    if (embed1.author?.name !== embed2.author?.name) return false;
-    if (embed1.author?.iconURL !== embed2.author?.iconURL) return false;
-    if (embed1.title !== embed2.title) return false;
-    if (embed1.description !== embed2.description) return false;
-    if (embed1.url !== embed2.url) return false;
-    if (embed1.color !== embed2.color) return false;
-    if (embed1.timestamp !== embed2.timestamp) return false;
-    if (embed1.footer?.text !== embed2.footer?.text) return false;
-    if (embed1.footer?.iconURL !== embed2.footer?.iconURL) return false;
-    if (embed1.thumbnail?.url !== embed2.thumbnail?.url) return false;
-    if (embed1.fields.length !== embed2.fields.length) return false;
-    for (let i = 0; i < embed1.fields.length; i++) {
-        if (embed1.fields[i].name !== embed2.fields[i]?.name) return false;
-        if (embed1.fields[i].value !== embed2.fields[i]?.value) return false;
-        if (embed1.fields[i].inline !== embed2.fields[i]?.inline) return false;
-    }
-    return true;
-};
-
 module.exports = {
-    validateEmbedColor,
-    embedEqual
+    validateEmbedColor
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const Discord = require('discord.js');
 const validateEmbedColor = (embedColor) => {
     try {
         embedColor = Discord.Util.resolveColor(embedColor);
-        return (!isNaN(embedColor) && typeof embedColor === 'number' ? true : false);
+        return Number.isFinite(embedColor);
     } catch {
         return false;
     }


### PR DESCRIPTION
<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->

recreated #405 
- [x] removed replaced global `isNan` with `Number.isFinite`
- [x] passed giveaway end time as number in embed timestamp (no need to convert to Date)
- [x] replaced substr with slice
- [x] used [MessageEmbed#equals](https://discord.js.org/#/docs/main/stable/class/MessageEmbed?scrollTo=equals) to check embed equal
- [x] fixed #408 

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.

Prettier removed some white spaces and empty lines, but they don't violate eslint rules or default prettier rules.
Codes are tested with my bot and working fine.