### PR TITLE
added extraData generic type to manager

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,29 @@
         "accessor-pairs": "off",
         "no-async-promise-executor": "off",
         "no-unused-vars": "off",
-        "node/no-missing-require": "off"
+        "node/no-missing-require": "off",
+        "no-restricted-globals": [
+            "error",
+            {
+              "name": "Buffer",
+              "message": "Import Buffer from `node:buffer` instead"
+            },
+            {
+              "name": "process",
+              "message": "Import process from `node:process` instead"
+            },
+            {
+              "name": "setTimeout",
+              "message": "Import setTimeout from `node:timers` instead"
+            },
+            {
+              "name": "setInterval",
+              "message": "Import setInterval from `node:timers` instead"
+            },
+            {
+              "name": "setImmediate",
+              "message": "Import setImmediate from `node:timers` instead"
+            }
+          ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "lint":"eslint .",
     "generate-docs": "jsdoc node_modules/.bin/jsdoc --configure .jsdoc.json --verbose"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint":"eslint .",
+    "lint": "eslint .",
     "generate-docs": "jsdoc node_modules/.bin/jsdoc --configure .jsdoc.json --verbose"
   },
   "repository": {
@@ -48,16 +48,19 @@
   "homepage": "https://discord-giveaways.js.org",
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "discord.js": "^13.3.1",
     "serialize-javascript": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.6.0",
+    "discord.js": "^13.5.0",
     "eslint": "^8.5.0",
     "eslint-plugin-node": "^11.1.0",
     "jsdoc": "^3.6.4",
     "jsdoc-skyceil": "Androz2091/jsdoc-skyceil",
     "typescript": "^4.5.4"
+  },
+  "peerDependencies": {
+    "discord.js": "^13.0.0"
   },
   "engines": {
     "node": ">=16.6.0"

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -1,7 +1,9 @@
 const merge = require('deepmerge');
 const serialize = require('serialize-javascript');
 const Discord = require('discord.js');
-const { EventEmitter } = require('events');
+const { EventEmitter } = require('node:events');
+const {setTimeout} = require('node:timers');
+
 const {
     GiveawayEditOptions,
     GiveawayData,

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -1,9 +1,8 @@
+const { EventEmitter } = require('node:events');
+const { setTimeout } = require('node:timers');
 const merge = require('deepmerge');
 const serialize = require('serialize-javascript');
 const Discord = require('discord.js');
-const { EventEmitter } = require('node:events');
-const {setTimeout} = require('node:timers');
-
 const {
     GiveawayEditOptions,
     GiveawayData,

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -114,7 +114,7 @@ class GiveawaysManager extends EventEmitter {
      * @returns {Discord.MessageEmbed} The generated embed
      */
     generateEndEmbed(giveaway, winners) {
-        let formattedWinners = winners.map((w) => `<@${w.id}>`).join(', ');
+        let formattedWinners = winners.map((w) => `${w}`).join(', ');
 
         const strings = {
             winners: giveaway.fillInString(giveaway.messages.winners),

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -1,4 +1,4 @@
-const { EventEmitter } = require('events');
+const { EventEmitter } = require('node:events');
 const merge = require('deepmerge');
 const serialize = require('serialize-javascript');
 const { writeFile, readFile, access } = require('fs/promises');
@@ -16,6 +16,7 @@ const {
 } = require('./Constants.js');
 const Giveaway = require('./Giveaway.js');
 const { validateEmbedColor } = require('./utils.js');
+const {setTimeout, setInterval} = require('node:timers');
 
 /**
  * Giveaways Manager

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -160,10 +160,10 @@ declare module 'discord-giveaways' {
         private ensureEndTimeout(): void;
         private checkWinnerEntry(user: User): Promise<boolean>;
         public checkBonusEntries(user: User): Promise<number>;
-        public fillInString(string: undefined | null): null;
         public fillInString(string: string): string;
-        public fillInEmbed(embed: undefined | null): null;
+        public fillInString(string: any): string | null;
         public fillInEmbed(embed: MessageEmbed | MessageEmbedOptions): MessageEmbed;
+        public fillInEmbed(embed: any): MessageEmbed | null;
         public exemptMembers(member: GuildMember): Promise<boolean>;
         public fetchMessage(): Promise<Message>;
         public edit(options: GiveawayEditOptions): Promise<Giveaway>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,219 +1,217 @@
-declare module 'discord-giveaways' {
-    import {
-        Client, ColorResolvable,
-        EmojiIdentifierResolvable, GuildMember, Message,
-        MessageEmbed,
-        MessageEmbedOptions,
-        MessageMentionOptions, MessageReaction, NewsChannel, PermissionResolvable, Snowflake, TextChannel, ThreadChannel, User
-    } from 'discord.js';
-    import { EventEmitter } from 'node:events';
+import {
+    Client, ColorResolvable,
+    EmojiIdentifierResolvable, GuildMember, Message,
+    MessageEmbed,
+    MessageEmbedOptions,
+    MessageMentionOptions, MessageReaction, NewsChannel, PermissionResolvable, Snowflake, TextChannel, ThreadChannel, User
+} from 'discord.js';
+import { EventEmitter } from 'node:events';
 
-    export const version: string;
-    export class GiveawaysManager extends EventEmitter {
-        constructor(client: Client, options?: GiveawaysManagerOptions, init?: boolean);
+export const version: string;
+export class GiveawaysManager<ExtraData> extends EventEmitter {
+    constructor(client: Client, options?: GiveawaysManagerOptions, init?: boolean);
 
-        public client: Client;
-        public giveaways: Giveaway[];
-        public options: GiveawaysManagerOptions;
-        public ready: boolean;
+    public client: Client;
+    public giveaways: Giveaway<ExtraData>[];
+    public options: GiveawaysManagerOptions;
+    public ready: boolean;
 
-        public delete(messageId: Snowflake, doNotDeleteMessage?: boolean): Promise<Giveaway>;
-        public deleteGiveaway(messageId: Snowflake): Promise<boolean>;
-        public edit(messageId: Snowflake, options: GiveawayEditOptions): Promise<Giveaway>;
-        public end(messageId: Snowflake, noWinnerMessage?: string | MessageObject): Promise<GuildMember[]>;
-        public reroll(messageId: Snowflake, options?: GiveawayRerollOptions): Promise<GuildMember[]>;
-        public start(channel: TextChannel | NewsChannel | ThreadChannel, options: GiveawayStartOptions): Promise<Giveaway>;
-        public pause(messageId: Snowflake, options?: Omit<PauseOptions, 'durationAfterPause'>): Promise<Giveaway>;
-        public unpause(messageId: Snowflake): Promise<Giveaway>;
-        public on<K extends keyof GiveawaysManagerEvents>(
-            event: K,
-            listener: (...args: GiveawaysManagerEvents[K]) => void
-        ): this;
+    public delete(messageId: Snowflake, doNotDeleteMessage?: boolean): Promise<Giveaway<ExtraData>>;
+    public deleteGiveaway(messageId: Snowflake): Promise<boolean>;
+    public edit(messageId: Snowflake, options: GiveawayEditOptions<ExtraData>): Promise<Giveaway<ExtraData>>;
+    public end(messageId: Snowflake, noWinnerMessage?: string | MessageObject): Promise<GuildMember[]>;
+    public reroll(messageId: Snowflake, options?: GiveawayRerollOptions): Promise<GuildMember[]>;
+    public start(channel: TextChannel | NewsChannel | ThreadChannel, options: GiveawayStartOptions<ExtraData>): Promise<Giveaway<ExtraData>>;
+    public pause(messageId: Snowflake, options?: Omit<PauseOptions, 'durationAfterPause'>): Promise<Giveaway<ExtraData>>;
+    public unpause(messageId: Snowflake): Promise<Giveaway<ExtraData>>;
+    public on<K extends keyof GiveawaysManagerEvents<ExtraData>>(
+        event: K,
+        listener: (...args: GiveawaysManagerEvents<ExtraData>[K]) => void
+    ): this;
 
-        public once<K extends keyof GiveawaysManagerEvents>(
-            event: K,
-            listener: (...args: GiveawaysManagerEvents[K]) => void
-        ): this;
+    public once<K extends keyof GiveawaysManagerEvents<ExtraData>>(
+        event: K,
+        listener: (...args: GiveawaysManagerEvents<ExtraData>[K]) => void
+    ): this;
 
-        public emit<K extends keyof GiveawaysManagerEvents>(event: K, ...args: GiveawaysManagerEvents[K]): boolean;
-    }
-    interface BonusEntry {
-        bonus(member?: GuildMember): number | Promise<number>;
-        cumulative?: boolean;
-    }
-    interface LastChanceOptions {
-        enabled?: boolean;
-        embedColor?: ColorResolvable;
-        content?: string;
-        threshold?: number;
-    }
-    interface PauseOptions {
-        isPaused?: boolean;
-        content?: string;
-        unPauseAfter?: number | null;
-        embedColor?: ColorResolvable;
-        durationAfterPause?: number | null;
-        infiniteDurationText?: string;
-    }
-    interface GiveawaysManagerOptions {
-        storage?: string;
-        forceUpdateEvery?: number;
-        endedGiveawaysLifetime?: number;
-        default?: {
-            botsCanWin?: boolean,
-            exemptPermissions?: PermissionResolvable[],
-            exemptMembers?: (member: GuildMember) => boolean | Promise<boolean>,
-            embedColor?: ColorResolvable,
-            embedColorEnd?: ColorResolvable,
-            reaction?: EmojiIdentifierResolvable,
-            lastChance?: LastChanceOptions;
-        };
-    }
-    interface GiveawayStartOptions {
-        prize: string;
-        winnerCount: number;
-        duration?: number; // can be null for drops
-        hostedBy?: User;
-        botsCanWin?: boolean;
-        exemptPermissions?: PermissionResolvable[];
-        exemptMembers?: (member: GuildMember) => boolean | Promise<boolean>;
-        bonusEntries?: BonusEntry[];
-        embedColor?: ColorResolvable;
-        embedColorEnd?: ColorResolvable;
-        reaction?: EmojiIdentifierResolvable;
-        messages?: GiveawaysMessages;
-        thumbnail?: string;
-        extraData?: any;
+    public emit<K extends keyof GiveawaysManagerEvents<ExtraData>>(event: K, ...args: GiveawaysManagerEvents<ExtraData>[K]): boolean;
+}
+export interface BonusEntry {
+    bonus(member?: GuildMember): number | Promise<number>;
+    cumulative?: boolean;
+}
+export interface LastChanceOptions {
+    enabled?: boolean;
+    embedColor?: ColorResolvable;
+    content?: string;
+    threshold?: number;
+}
+export interface PauseOptions {
+    isPaused?: boolean;
+    content?: string;
+    unPauseAfter?: number | null;
+    embedColor?: ColorResolvable;
+    durationAfterPause?: number | null;
+    infiniteDurationText?: string;
+}
+export interface GiveawaysManagerOptions {
+    storage?: string;
+    forceUpdateEvery?: number;
+    endedGiveawaysLifetime?: number;
+    default?: {
+        botsCanWin?: boolean,
+        exemptPermissions?: PermissionResolvable[],
+        exemptMembers?: (member: GuildMember) => boolean | Promise<boolean>,
+        embedColor?: ColorResolvable,
+        embedColorEnd?: ColorResolvable,
+        reaction?: EmojiIdentifierResolvable,
         lastChance?: LastChanceOptions;
-        pauseOptions?: PauseOptions;
-        isDrop?: boolean;
-        allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
-    }
-    interface GiveawaysMessages {
-        giveaway?: string;
-        giveawayEnded?: string;
-        inviteToParticipate?: string;
-        timeRemaining?: string;
-        winMessage?: string | MessageObject;
-        drawing?: string;
-        dropMessage?: string;
-        embedFooter?: string | { text?: string; iconURL?: string; };
-        noWinner?: string;
-        winners?: string;
-        endedAt?: string;
-        hostedBy?: string;
-    }
-    interface MessageObject {
-        content?: string;
-        embed?: MessageEmbed | MessageEmbedOptions;
-        replyToGiveaway?: boolean;
-    }
-    interface GiveawaysManagerEvents {
-        giveawayDeleted: [Giveaway];
-        giveawayEnded: [Giveaway, GuildMember[]];
-        giveawayRerolled: [Giveaway, GuildMember[]];
-        giveawayReactionAdded: [Giveaway, GuildMember, MessageReaction];
-        giveawayReactionRemoved: [Giveaway, GuildMember, MessageReaction];
-        endedGiveawayReactionAdded: [Giveaway, GuildMember, MessageReaction];
-    }
-    class Giveaway<T=any> extends EventEmitter {
-        constructor(manager: GiveawaysManager, options: GiveawayData);
+    };
+}
+export interface GiveawayStartOptions<ExtraData> {
+    prize: string;
+    winnerCount: number;
+    duration?: number; // can be null for drops
+    hostedBy?: User;
+    botsCanWin?: boolean;
+    exemptPermissions?: PermissionResolvable[];
+    exemptMembers?: (member: GuildMember) => boolean | Promise<boolean>;
+    bonusEntries?: BonusEntry[];
+    embedColor?: ColorResolvable;
+    embedColorEnd?: ColorResolvable;
+    reaction?: EmojiIdentifierResolvable;
+    messages?: GiveawaysMessages;
+    thumbnail?: string;
+    extraData?: ExtraData;
+    lastChance?: LastChanceOptions;
+    pauseOptions?: PauseOptions;
+    isDrop?: boolean;
+    allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
+}
+export interface GiveawaysMessages {
+    giveaway?: string;
+    giveawayEnded?: string;
+    inviteToParticipate?: string;
+    timeRemaining?: string;
+    winMessage?: string | MessageObject;
+    drawing?: string;
+    dropMessage?: string;
+    embedFooter?: string | { text?: string; iconURL?: string; };
+    noWinner?: string;
+    winners?: string;
+    endedAt?: string;
+    hostedBy?: string;
+}
+export interface MessageObject {
+    content?: string;
+    embed?: MessageEmbed | MessageEmbedOptions;
+    replyToGiveaway?: boolean;
+}
+export interface GiveawaysManagerEvents<ExtraData> {
+    giveawayDeleted: [Giveaway<ExtraData>];
+    giveawayEnded: [Giveaway<ExtraData>, GuildMember[]];
+    giveawayRerolled: [Giveaway<ExtraData>, GuildMember[]];
+    giveawayReactionAdded: [Giveaway<ExtraData>, GuildMember, MessageReaction];
+    giveawayReactionRemoved: [Giveaway<ExtraData>, GuildMember, MessageReaction];
+    endedGiveawayReactionAdded: [Giveaway<ExtraData>, GuildMember, MessageReaction];
+}
+export class Giveaway<ExtraData = any> extends EventEmitter {
+    constructor(manager: GiveawaysManager<ExtraData>, options: GiveawayData<ExtraData>);
 
-        public channelId: Snowflake;
-        public client: Client;
-        public endAt: number;
-        public ended: boolean;
-        public guildId: Snowflake;
-        public hostedBy?: User;
-        public manager: GiveawaysManager;
-        public message: Message | null;
-        public messageId: Snowflake;
-        public messages: Required<GiveawaysMessages>;
-        public thumbnail?: string;
-        public extraData?: T;
-        public options: GiveawayData;
-        public prize: string;
-        public startAt: number;
-        public winnerCount: number;
-        public winnerIds: Snowflake[];
-        public allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
-        private endTimeout?: NodeJS.Timeout;
+    public channelId: Snowflake;
+    public client: Client;
+    public endAt: number;
+    public ended: boolean;
+    public guildId: Snowflake;
+    public hostedBy?: User;
+    public manager: GiveawaysManager<ExtraData>;
+    public message: Message | null;
+    public messageId: Snowflake;
+    public messages: Required<GiveawaysMessages>;
+    public thumbnail?: string;
+    public extraData?: ExtraData;
+    public options: GiveawayData<ExtraData>;
+    public prize: string;
+    public startAt: number;
+    public winnerCount: number;
+    public winnerIds: Snowflake[];
+    public allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
+    private endTimeout?: NodeJS.Timeout;
 
-        // getters calculated using default manager options
-        readonly exemptPermissions: PermissionResolvable[];
-        readonly embedColor: ColorResolvable;
-        readonly embedColorEnd: ColorResolvable;
-        readonly botsCanWin: boolean;
-        readonly reaction: EmojiIdentifierResolvable;
-        readonly lastChance: Required<LastChanceOptions>;
+    // getters calculated using default manager options
+    readonly exemptPermissions: PermissionResolvable[];
+    readonly embedColor: ColorResolvable;
+    readonly embedColorEnd: ColorResolvable;
+    readonly botsCanWin: boolean;
+    readonly reaction: EmojiIdentifierResolvable;
+    readonly lastChance: Required<LastChanceOptions>;
 
-        // getters calculated using other values
-        readonly remainingTime: number;
-        readonly duration: number;
-        readonly messageURL: string;
-        readonly exemptMembersFunction: Function | null;
-        readonly bonusEntries: BonusEntry[];
-        readonly data: GiveawayData;
-        readonly pauseOptions: Required<PauseOptions>;
-        readonly isDrop: boolean;
+    // getters calculated using other values
+    readonly remainingTime: number;
+    readonly duration: number;
+    readonly messageURL: string;
+    readonly exemptMembersFunction: Function | null;
+    readonly bonusEntries: BonusEntry[];
+    readonly data: GiveawayData<ExtraData>;
+    readonly pauseOptions: Required<PauseOptions>;
+    readonly isDrop: boolean;
 
-        private ensureEndTimeout(): void;
-        private checkWinnerEntry(user: User): Promise<boolean>;
-        public checkBonusEntries(user: User): Promise<number>;
-        public fillInString(string: string): string;
-        public fillInString(string: any): string | null;
-        public fillInEmbed(embed: MessageEmbed | MessageEmbedOptions): MessageEmbed;
-        public fillInEmbed(embed: any): MessageEmbed | null;
-        public exemptMembers(member: GuildMember): Promise<boolean>;
-        public fetchMessage(): Promise<Message>;
-        public edit(options: GiveawayEditOptions): Promise<Giveaway>;
-        public end(noWinnerMessage?: string | MessageObject): Promise<GuildMember[]>;
-        public reroll(options?: GiveawayRerollOptions): Promise<GuildMember[]>;
-        public roll(winnerCount?: number): Promise<GuildMember[]>;
-        public pause(options?: Omit<PauseOptions, 'durationAfterPause'>): Promise<Giveaway>;
-        public unpause(): Promise<Giveaway>;
-    }
-    interface GiveawayEditOptions {
-        newWinnerCount?: number;
-        newPrize?: string;
-        addTime?: number;
-        setEndTimestamp?: number;
-        newMessages?: GiveawaysMessages;
-        newThumbnail?: string;
-        newBonusEntries?: BonusEntry[];
-        newExtraData?: any;
-        newLastChance?: LastChanceOptions;
-    }
-    interface GiveawayRerollOptions {
-        winnerCount?: number;
-        messages?: {
-            congrat?: string | MessageObject;
-            error?: string | MessageObject;
-        };
-    }
-    interface GiveawayData<T=any> {
-        startAt: number;
-        endAt: number;
-        winnerCount: number;
-        messages: Required<GiveawaysMessages>;
-        prize: string;
-        channelId: Snowflake;
-        guildId: Snowflake;
-        ended: boolean;
-        winnerIds?: Snowflake[];
-        messageId: Snowflake;
-        reaction?: EmojiIdentifierResolvable;
-        exemptPermissions?: PermissionResolvable[];
-        exemptMembers?: string;
-        bonusEntries?: string;
-        embedColor?: ColorResolvable;
-        embedColorEnd?: ColorResolvable;
-        thumbnail?: string;
-        hostedBy?: string;
-        extraData?: T;
-        lastChance?: LastChanceOptions;
-        pauseOptions?: PauseOptions;
-        isDrop?: boolean;
-        allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
-    }
+    private ensureEndTimeout(): void;
+    private checkWinnerEntry(user: User): Promise<boolean>;
+    public checkBonusEntries(user: User): Promise<number>;
+    public fillInString(string: string): string;
+    public fillInString(string: any): string | null;
+    public fillInEmbed(embed: MessageEmbed | MessageEmbedOptions): MessageEmbed;
+    public fillInEmbed(embed: any): MessageEmbed | null;
+    public exemptMembers(member: GuildMember): Promise<boolean>;
+    public fetchMessage(): Promise<Message>;
+    public edit(options: GiveawayEditOptions<ExtraData>): Promise<Giveaway<ExtraData>>;
+    public end(noWinnerMessage?: string | MessageObject): Promise<GuildMember[]>;
+    public reroll(options?: GiveawayRerollOptions): Promise<GuildMember[]>;
+    public roll(winnerCount?: number): Promise<GuildMember[]>;
+    public pause(options?: Omit<PauseOptions, 'durationAfterPause'>): Promise<Giveaway<ExtraData>>;
+    public unpause(): Promise<Giveaway<ExtraData>>;
+}
+export interface GiveawayEditOptions<ExtraData> {
+    newWinnerCount?: number;
+    newPrize?: string;
+    addTime?: number;
+    setEndTimestamp?: number;
+    newMessages?: GiveawaysMessages;
+    newThumbnail?: string;
+    newBonusEntries?: BonusEntry[];
+    newExtraData?: ExtraData;
+    newLastChance?: LastChanceOptions;
+}
+export interface GiveawayRerollOptions {
+    winnerCount?: number;
+    messages?: {
+        congrat?: string | MessageObject;
+        error?: string | MessageObject;
+    };
+}
+export interface GiveawayData<ExtraData = any> {
+    startAt: number;
+    endAt: number;
+    winnerCount: number;
+    messages: Required<GiveawaysMessages>;
+    prize: string;
+    channelId: Snowflake;
+    guildId: Snowflake;
+    ended: boolean;
+    winnerIds?: Snowflake[];
+    messageId: Snowflake;
+    reaction?: EmojiIdentifierResolvable;
+    exemptPermissions?: PermissionResolvable[];
+    exemptMembers?: string;
+    bonusEntries?: string;
+    embedColor?: ColorResolvable;
+    embedColorEnd?: ColorResolvable;
+    thumbnail?: string;
+    hostedBy?: string;
+    extraData?: ExtraData;
+    lastChance?: LastChanceOptions;
+    pauseOptions?: PauseOptions;
+    isDrop?: boolean;
+    allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -116,7 +116,7 @@ declare module 'discord-giveaways' {
         giveawayReactionRemoved: [Giveaway, GuildMember, MessageReaction];
         endedGiveawayReactionAdded: [Giveaway, GuildMember, MessageReaction];
     }
-    class Giveaway extends EventEmitter {
+    class Giveaway<T=any> extends EventEmitter {
         constructor(manager: GiveawaysManager, options: GiveawayData);
 
         public channelId: Snowflake;
@@ -130,7 +130,7 @@ declare module 'discord-giveaways' {
         public messageId: Snowflake;
         public messages: Required<GiveawaysMessages>;
         public thumbnail?: string;
-        public extraData?: any;
+        public extraData?: T;
         public options: GiveawayData;
         public prize: string;
         public startAt: number;
@@ -191,7 +191,7 @@ declare module 'discord-giveaways' {
             error?: string | MessageObject;
         };
     }
-    interface GiveawayData {
+    interface GiveawayData<T=any> {
         startAt: number;
         endAt: number;
         winnerCount: number;
@@ -210,7 +210,7 @@ declare module 'discord-giveaways' {
         embedColorEnd?: ColorResolvable;
         thumbnail?: string;
         hostedBy?: string;
-        extraData?: any;
+        extraData?: T;
         lastChance?: LastChanceOptions;
         pauseOptions?: PauseOptions;
         isDrop?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -160,9 +160,9 @@ declare module 'discord-giveaways' {
         private ensureEndTimeout(): void;
         private checkWinnerEntry(user: User): Promise<boolean>;
         public checkBonusEntries(user: User): Promise<number>;
-        public fillInString(string?: null): null;
+        public fillInString(string: undefined | null): null;
         public fillInString(string: string): string;
-        public fillInEmbed(embed?: null): null;
+        public fillInEmbed(embed: undefined | null): null;
         public fillInEmbed(embed: MessageEmbed | MessageEmbedOptions): MessageEmbed;
         public exemptMembers(member: GuildMember): Promise<boolean>;
         public fetchMessage(): Promise<Message>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,22 +1,12 @@
 declare module 'discord-giveaways' {
-    import { EventEmitter } from 'events';
     import {
-        Client,
-        PermissionResolvable,
-        ColorResolvable,
-        EmojiIdentifierResolvable,
-        User,
-        Snowflake,
-        GuildMember,
-        TextChannel,
-        MessageReaction,
-        Message,
+        Client, ColorResolvable,
+        EmojiIdentifierResolvable, GuildMember, Message,
         MessageEmbed,
         MessageEmbedOptions,
-        MessageMentionOptions,
-        NewsChannel,
-        ThreadChannel
+        MessageMentionOptions, MessageReaction, NewsChannel, PermissionResolvable, Snowflake, TextChannel, ThreadChannel, User
     } from 'discord.js';
+    import { EventEmitter } from 'node:events';
 
     export const version: string;
     export class GiveawaysManager extends EventEmitter {
@@ -170,8 +160,10 @@ declare module 'discord-giveaways' {
         private ensureEndTimeout(): void;
         private checkWinnerEntry(user: User): Promise<boolean>;
         public checkBonusEntries(user: User): Promise<number>;
-        public fillInString(string: string): string | null;
-        public fillInEmbed(embed: MessageEmbed | MessageEmbedOptions): MessageEmbed | null;
+        public fillInString(string?: null): null;
+        public fillInString(string: string): string;
+        public fillInEmbed(embed?: null): null;
+        public fillInEmbed(embed: MessageEmbed | MessageEmbedOptions): MessageEmbed;
         public exemptMembers(member: GuildMember): Promise<boolean>;
         public fetchMessage(): Promise<Message>;
         public edit(options: GiveawayEditOptions): Promise<Giveaway>;


### PR DESCRIPTION
<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->

- [x] added extraData generic type to manager so that it can give autocomplete in gw start options, edit and all. x-ref #412 
- [x] also change declare module to top level d.ts with exports
- [x] discord.js is now a dev dependency. Also added v13.0.0 in peer deps.

I did this because every user will be downloading djs, so there is no need to redownload the same.

## Status

- [x] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.


## How to use these generic types?

You can use ExtraData interface in GiveawayManager's generic type. It's optional, if u don't provide the type it'll become `any` type as before.
```ts
  const manager = new GiveawayManager<ExtraData>(client, {
    default: {
      botsCanWin: false,
      embedColor: "#03FEE0",
      embedColorEnd: "#ffffff",
      reaction: "🎉",
    },
  });
```

Now you'll get autocomplete and validation in giveaway start options also.
![image](https://user-images.githubusercontent.com/74945038/147870225-5286b284-6705-44dd-9cca-ae8508bc8eec.png)

If you are extending the manager to change generate embed, then you can add the extraData generic type in `Giveaway` class

```ts
generateMainEmbed(
    giveaway: Giveaway<GiveawayExtraData>,
    lastChanceEnabled = false
  ): MessageEmbed {
}
```