### PR TITLE
Add Missing Giveaway Events

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -277,6 +277,7 @@ class GiveawaysManager extends EventEmitter {
             giveaway.message = reaction.message;
             this.giveaways.push(giveaway);
             await this.saveGiveaway(giveaway.messageId, giveaway.data);
+            this.emit('giveawayCreated', giveaway);
             resolve(giveaway);
             if (giveaway.isDrop) {
                 reaction.message

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -331,6 +331,7 @@ class GiveawaysManager extends EventEmitter {
             const giveaway = this.giveaways.find((g) => g.messageId === messageId);
             if (!giveaway) return reject('No giveaway found with message Id ' + messageId + '.');
             giveaway.pause(options).then(resolve).catch(reject);
+            this.emit('giveawayPaused', giveaway);
         });
     }
 
@@ -347,6 +348,7 @@ class GiveawaysManager extends EventEmitter {
             const giveaway = this.giveaways.find((g) => g.messageId === messageId);
             if (!giveaway) return reject('No giveaway found with message Id ' + messageId + '.');
             giveaway.unpause().then(resolve).catch(reject);
+            this.emit('giveawayUnpaused', giveaway);
         });
     }
 
@@ -368,6 +370,7 @@ class GiveawaysManager extends EventEmitter {
             const giveaway = this.giveaways.find((g) => g.messageId === messageId);
             if (!giveaway) return reject('No giveaway found with message Id ' + messageId + '.');
             giveaway.edit(options).then(resolve).catch(reject);
+            this.emit('giveawayEdited', giveaway);
         });
     }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -120,6 +120,7 @@ export interface MessageObject {
     replyToGiveaway?: boolean;
 }
 export interface GiveawaysManagerEvents<ExtraData = any> {
+    giveawayCreated: [Giveaway<ExtraData>];
     giveawayDeleted: [Giveaway<ExtraData>];
     giveawayEdited: [Giveaway<ExtraData>];
     giveawayEnded: [Giveaway<ExtraData>, GuildMember[]];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -121,10 +121,13 @@ export interface MessageObject {
 }
 export interface GiveawaysManagerEvents<ExtraData = any> {
     giveawayDeleted: [Giveaway<ExtraData>];
+    giveawayEdited: [Giveaway<ExtraData>];
     giveawayEnded: [Giveaway<ExtraData>, GuildMember[]];
     giveawayRerolled: [Giveaway<ExtraData>, GuildMember[]];
     giveawayReactionAdded: [Giveaway<ExtraData>, GuildMember, MessageReaction];
     giveawayReactionRemoved: [Giveaway<ExtraData>, GuildMember, MessageReaction];
+    giveawayPaused: [Giveaway<ExtraData>];
+    giveawayUnpaused: [Giveaway<ExtraData>];
     endedGiveawayReactionAdded: [Giveaway<ExtraData>, GuildMember, MessageReaction];
 }
 export class Giveaway<ExtraData = any> extends EventEmitter {


### PR DESCRIPTION
## Changes
This PR adds additional events which currently missing such as:
- `giveawayCreated` 
    - Fired whenever a new giveaway was created
-  `giveawayEdited` 
    - Fired whenever an existing giveaway was edited
-  `giveawayPaused` 
    - Fired whenever an existing giveaway was paused
- `giveawayUnpaused` 
    - Fired whenever an existing giveaway was unpaused

Let me know if I missed something in this PR so I can adjust the necessary change.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.