### PR TITLE
fix: fix unpause after condition

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -539,7 +539,7 @@ class GiveawaysManager extends EventEmitter {
                 }
                 if (
                     Number.isFinite(giveaway.pauseOptions.unPauseAfter) &&
-                    Date.now() < giveaway.pauseOptions.unPauseAfter
+                    Date.now() > giveaway.pauseOptions.unPauseAfter
                 ) {
                     return this.unpause(giveaway.messageId).catch(() => {});
                 }


### PR DESCRIPTION
<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->
Current condition `Date.now() < giveaway.pauseOptions.unPauseAfter` checks for `unPauseAfter` is in future or not. But it should check for past.
## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.