### PR TITLE
Change in shardClientUtil

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -646,12 +646,12 @@ class GiveawaysManager extends EventEmitter {
 
         // Filter giveaways for each shard
         if (this.client.shard && this.client.guilds.cache.size) {
-            const shardId = this.client.shard.shardIdForGuildId(
+            const shardId = Discord.ShardClientUtil.shardIdForGuildId(
                 this.client.guilds.cache.first().id,
                 this.client.shard.count
             );
             rawGiveaways = rawGiveaways.filter(
-                (g) => shardId === this.client.shard.shardIdForGuildId(g.guildId, this.client.shard.count)
+                (g) => shardId === Discord.ShardClientUtil.shardIdForGuildId(g.guildId, this.client.shard.count)
             );
         }
 


### PR DESCRIPTION


## Changes
For some reason, ShardClientUtil doesn't work for shards.ShardClientUtil for everyone so I change it to Discord.ShardClientUtil so that it won't throw errors for anyone

## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.