### PR TITLE
fix: clone the given actionrow properly

### DIFF
--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -379,7 +379,7 @@ class Giveaway extends EventEmitter {
     fillInComponents(components) {
         if (!Array.isArray(components)) return null;
         return components.map((row) => {
-            row = new Discord.MessageActionRow(row);
+            row = new Discord.MessageActionRow(row instanceof Discord.MessageActionRow ? row.toJSON() : row);
             row.components = row.components.map((component) => {
                 component.customId &&= this.fillInString(component.customId);
                 component.label &&= this.fillInString(component.label);


### PR DESCRIPTION
<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->
fix regression from https://github.com/Androz2091/discord-giveaways/pull/422

after https://github.com/discordjs/discord.js/pull/7140
`new MessageActionRow(ActionRowInstance)` will return the given instance. And when replacing `{var}` it'll replace in the original ActionRow. So from 2nd gw it'll show infos from 1st gw

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.