### PR TITLE
🐛 Check if embed was edited on end()

### DIFF
--- a/examples/custom-databases/mongoose.js
+++ b/examples/custom-databases/mongoose.js
@@ -41,6 +41,7 @@ const giveawaySchema = new mongoose.Schema({
         hostedBy: String
     },
     thumbnail: String,
+    image: String,
     hostedBy: String,
     winnerIds: { type: [String], default: undefined },
     reaction: mongoose.Mixed,

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -2,6 +2,7 @@ const Discord = require('discord.js');
 
 exports.DEFAULT_CHECK_INTERVAL = 15_000;
 exports.DELETE_DROP_DATA_AFTER = 6.048e+8; // 1 week
+exports.MAX_TIME_TO_EDIT_EMBED = 30_000;
 
 /**
  * The Giveaway messages that are used to display the giveaway content.

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -841,22 +841,23 @@ class Giveaway extends EventEmitter {
                     });
                 }
             } else {
+                const embed1 = this.manager.generateNoValidParticipantsEndEmbed(this);
                 const date = Date.now();
                 do {
                     await this.message
                         .edit({
                             content: this.fillInString(this.messages.giveawayEnded),
-                            embeds: [this.manager.generateNoValidParticipantsEndEmbed(this)],
+                            embeds: [embed1],
                             allowedMentions: this.allowedMentions
                         })
                         .catch(() => {});
                 } while (
                     this.message &&
-                    !embed.equals(this.message.embeds[0]) &&
+                    !embed1.equals(this.message.embeds[0]) &&
                     Date.now() - date < MAX_TIME_TO_EDIT_EMBED
                 );
 
-                if (!this.message || !embed.equals(this.message.embeds[0])) {
+                if (!this.message || !embed1.equals(this.message.embeds[0])) {
                     this.isEnding = false;
                     return reject(
                         'Ending aborted because giveaway with message Id ' +
@@ -871,11 +872,11 @@ class Giveaway extends EventEmitter {
                 await this.manager.editGiveaway(this.messageId, this.data);
 
                 const message = this.fillInString(noWinnerMessage?.content || noWinnerMessage);
-                const embed = this.fillInEmbed(noWinnerMessage?.embed);
-                if (message || embed) {
+                const embed2 = this.fillInEmbed(noWinnerMessage?.embed);
+                if (message || embed2) {
                     channel.send({
                         content: message,
-                        embeds: embed ? [embed] : null,
+                        embeds: embed2 ? [embed2] : null,
                         components: this.fillInComponents(noWinnerMessage?.components),
                         allowedMentions: this.allowedMentions,
                         reply: {

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -528,7 +528,7 @@ class Giveaway extends EventEmitter {
     async roll(winnerCount = this.winnerCount) {
         if (!this.message) return [];
 
-        let guild = this.message.guild ?? await this.client.guilds.fetch(this.guildId).catch(() => {});
+        let guild = this.message.guild;
 
         // Fetch all guild members if the intent is available
         if (new Discord.Intents(this.client.options.intents).has(Discord.Intents.FLAGS.GUILD_MEMBERS)) {

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -533,7 +533,8 @@ class Giveaway extends EventEmitter {
             // Try to fetch the guild from the client if the guild instance of the message does not have its shard defined
             if (this.client.shard && !guild.shard) {
                 guild = (await this.client.guilds.fetch(guild.id).catch(() => {})) ?? guild;
-                this.message = await this.fetchMessage().catch(() => {});
+                // "Update" the message instance too, if possible. If not, reassign to prevent ending error.
+                this.message = (await this.fetchMessage().catch(() => {})) ?? this.message;
             }
             await guild.members.fetch().catch(() => {});
         }

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -688,16 +688,17 @@ class Giveaway extends EventEmitter {
                 const embed = this.manager.generateEndEmbed(this, winners);
                 const date = Date.now();
                 do {
-                    this.message = await this.message
+                    const message = await this.message
                         .edit({
                             content: this.fillInString(this.messages.giveawayEnded),
                             embeds: [embed],
                             allowedMentions: this.allowedMentions
                         })
                         .catch(() => {});
-                } while (!embed.equals(this.message?.embeds[0]) && Date.now() - date < MAX_TIME_TO_EDIT_EMBED);
+                    if (message) this.message = message;
+                } while (!embed.equals(this.message.embeds[0]) && Date.now() - date < MAX_TIME_TO_EDIT_EMBED);
 
-                if (!embed.equals(this.message?.embeds[0])) {
+                if (!embed.equals(this.message.embeds[0])) {
                     this.winnerIds = [];
                     this.isEnding = false;
                     return reject(
@@ -848,19 +849,19 @@ class Giveaway extends EventEmitter {
                     });
                 }
 
-
                 const date = Date.now();
                 do {
-                    this.message = await this.message
+                    const message = await this.message
                         .edit({
                             content: this.fillInString(this.messages.giveawayEnded),
                             embeds: [this.manager.generateNoValidParticipantsEndEmbed(this)],
                             allowedMentions: this.allowedMentions
                         })
                         .catch(() => {});
-                } while (!embed.equals(this.message?.embeds[0]) && Date.now() - date < MAX_TIME_TO_EDIT_EMBED);
+                    if (message) this.message = message;
+                } while (!embed.equals(this.message.embeds[0]) && Date.now() - date < MAX_TIME_TO_EDIT_EMBED);
 
-                if (!embed.equals(this.message?.embeds[0])) {
+                if (!embed.equals(this.message.embeds[0])) {
                     this.isEnding = false;
                     return reject(
                         'Ending aborted because giveaway with message Id ' +

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -528,7 +528,7 @@ class Giveaway extends EventEmitter {
     async roll(winnerCount = this.winnerCount) {
         if (!this.message) return [];
 
-        let guild = this.message.guild;
+        let guild = this.message.guild ?? await this.client.guilds.fetch(this.guildId).catch(() => {});
 
         // Fetch all guild members if the intent is available
         if (new Discord.Intents(this.client.options.intents).has(Discord.Intents.FLAGS.GUILD_MEMBERS)) {

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -724,39 +724,47 @@ class Giveaway extends EventEmitter {
                 if (message?.length > 2000) {
                     const firstContentPart = winMessage.slice(0, winMessage.indexOf('{winners}'));
                     if (firstContentPart.length) {
-                        channel.send({
-                            content: firstContentPart,
-                            allowedMentions: this.allowedMentions,
-                            reply: {
-                                messageReference:
-                                    typeof this.messages.winMessage.replyToGiveaway === 'boolean'
-                                        ? this.messageId
-                                        : undefined,
-                                failIfNotExists: false
-                            }
-                        });
+                        await channel
+                            .send({
+                                content: firstContentPart,
+                                allowedMentions: this.allowedMentions,
+                                reply: {
+                                    messageReference:
+                                        typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                            ? this.messageId
+                                            : undefined,
+                                    failIfNotExists: false
+                                }
+                            })
+                            .catch(() => {});
                     }
                     while (formattedWinners.length >= 2000) {
-                        await channel.send({
-                            content: formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
-                            allowedMentions: this.allowedMentions
-                        });
+                        await channel
+                            .send({
+                                content: formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
+                                allowedMentions: this.allowedMentions
+                            })
+                            .catch(() => {});
                         formattedWinners = formattedWinners.slice(
                             formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
                         );
                     }
-                    channel.send({ content: formattedWinners, allowedMentions: this.allowedMentions });
+                    await channel
+                        .send({ content: formattedWinners, allowedMentions: this.allowedMentions })
+                        .catch(() => {});
 
                     const lastContentPart = winMessage.slice(winMessage.indexOf('{winners}') + 9);
                     if (lastContentPart.length) {
-                        channel.send({
-                            content: lastContentPart,
-                            components:
-                                this.messages.winMessage.embed && typeof this.messages.winMessage.embed === 'object'
-                                    ? null
-                                    : components,
-                            allowedMentions: this.allowedMentions
-                        });
+                        await channel
+                            .send({
+                                content: lastContentPart,
+                                components:
+                                    this.messages.winMessage.embed && typeof this.messages.winMessage.embed === 'object'
+                                        ? null
+                                        : components,
+                                allowedMentions: this.allowedMentions
+                            })
+                            .catch(() => {});
                     }
                 }
 
@@ -766,28 +774,11 @@ class Giveaway extends EventEmitter {
                     const embedDescription = embed.description?.replace('{winners}', formattedWinners) ?? '';
 
                     if (embedDescription.length <= 4096) {
-                        channel.send({
-                            content: message?.length <= 2000 ? message : null,
-                            embeds: [embed.setDescription(embedDescription)],
-                            components,
-                            allowedMentions: this.allowedMentions,
-                            reply: {
-                                messageReference:
-                                    !(message?.length > 2000) &&
-                                    typeof this.messages.winMessage.replyToGiveaway === 'boolean'
-                                        ? this.messageId
-                                        : undefined,
-                                failIfNotExists: false
-                            }
-                        });
-                    } else {
-                        const firstEmbed = new Discord.MessageEmbed(embed).setDescription(
-                            embed.description.slice(0, embed.description.indexOf('{winners}'))
-                        );
-                        if (firstEmbed.length) {
-                            channel.send({
+                        await channel
+                            .send({
                                 content: message?.length <= 2000 ? message : null,
-                                embeds: [firstEmbed],
+                                embeds: [embed.setDescription(embedDescription)],
+                                components,
                                 allowedMentions: this.allowedMentions,
                                 reply: {
                                     messageReference:
@@ -797,48 +788,77 @@ class Giveaway extends EventEmitter {
                                             : undefined,
                                     failIfNotExists: false
                                 }
-                            });
+                            })
+                            .catch(() => {});
+                    } else {
+                        const firstEmbed = new Discord.MessageEmbed(embed).setDescription(
+                            embed.description.slice(0, embed.description.indexOf('{winners}'))
+                        );
+                        if (firstEmbed.length) {
+                            await channel
+                                .send({
+                                    content: message?.length <= 2000 ? message : null,
+                                    embeds: [firstEmbed],
+                                    allowedMentions: this.allowedMentions,
+                                    reply: {
+                                        messageReference:
+                                            !(message?.length > 2000) &&
+                                            typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                                ? this.messageId
+                                                : undefined,
+                                        failIfNotExists: false
+                                    }
+                                })
+                                .catch(() => {});
                         }
 
                         const tempEmbed = new Discord.MessageEmbed().setColor(embed.color);
                         while (formattedWinners.length >= 4096) {
-                            await channel.send({
-                                embeds: [
-                                    tempEmbed.setDescription(
-                                        formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095)) + ','
-                                    )
-                                ],
-                                allowedMentions: this.allowedMentions
-                            });
+                            await channel
+                                .send({
+                                    embeds: [
+                                        tempEmbed.setDescription(
+                                            formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095)) + ','
+                                        )
+                                    ],
+                                    allowedMentions: this.allowedMentions
+                                })
+                                .catch(() => {});
                             formattedWinners = formattedWinners.slice(
                                 formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095) + 2).length
                             );
                         }
-                        channel.send({
-                            embeds: [tempEmbed.setDescription(formattedWinners)],
-                            allowedMentions: this.allowedMentions
-                        });
+                        await channel
+                            .send({
+                                embeds: [tempEmbed.setDescription(formattedWinners)],
+                                allowedMentions: this.allowedMentions
+                            })
+                            .catch(() => {});
 
                         const lastEmbed = tempEmbed.setDescription(
                             embed.description.slice(embed.description.indexOf('{winners}') + 9)
                         );
                         if (lastEmbed.length) {
-                            channel.send({ embeds: [lastEmbed], components, allowedMentions: this.allowedMentions });
+                            await channel
+                                .send({ embeds: [lastEmbed], components, allowedMentions: this.allowedMentions })
+                                .catch(() => {});
                         }
                     }
                 } else if (message?.length <= 2000) {
-                    channel.send({
-                        content: message,
-                        components,
-                        allowedMentions: this.allowedMentions,
-                        reply: {
-                            messageReference:
-                                typeof this.messages.winMessage.replyToGiveaway === 'boolean'
-                                    ? this.messageId
-                                    : undefined,
-                            failIfNotExists: false
-                        }
-                    });
+                    await channel
+                        .send({
+                            content: message,
+                            components,
+                            allowedMentions: this.allowedMentions,
+                            reply: {
+                                messageReference:
+                                    typeof this.messages.winMessage.replyToGiveaway === 'boolean'
+                                        ? this.messageId
+                                        : undefined,
+                                failIfNotExists: false
+                            }
+                        })
+                        .catch(() => {});
                 }
             } else {
                 const embed1 = this.manager.generateNoValidParticipantsEndEmbed(this);
@@ -874,17 +894,19 @@ class Giveaway extends EventEmitter {
                 const message = this.fillInString(noWinnerMessage?.content || noWinnerMessage);
                 const embed2 = this.fillInEmbed(noWinnerMessage?.embed);
                 if (message || embed2) {
-                    channel.send({
-                        content: message,
-                        embeds: embed2 ? [embed2] : null,
-                        components: this.fillInComponents(noWinnerMessage?.components),
-                        allowedMentions: this.allowedMentions,
-                        reply: {
-                            messageReference:
-                                typeof noWinnerMessage?.replyToGiveaway === 'boolean' ? this.messageId : undefined,
-                            failIfNotExists: false
-                        }
-                    });
+                    await channel
+                        .send({
+                            content: message,
+                            embeds: embed2 ? [embed2] : null,
+                            components: this.fillInComponents(noWinnerMessage?.components),
+                            allowedMentions: this.allowedMentions,
+                            reply: {
+                                messageReference:
+                                    typeof noWinnerMessage?.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                                failIfNotExists: false
+                            }
+                        })
+                        .catch(() => {});
                 }
             }
 
@@ -948,40 +970,48 @@ class Giveaway extends EventEmitter {
                 if (message?.length > 2000) {
                     const firstContentPart = congratMessage.slice(0, congratMessage.indexOf('{winners}'));
                     if (firstContentPart.length) {
-                        channel.send({
-                            content: firstContentPart,
-                            allowedMentions: this.allowedMentions,
-                            reply: {
-                                messageReference:
-                                    typeof options.messages.congrat.replyToGiveaway === 'boolean'
-                                        ? this.messageId
-                                        : undefined,
-                                failIfNotExists: false
-                            }
-                        });
+                        await channel
+                            .send({
+                                content: firstContentPart,
+                                allowedMentions: this.allowedMentions,
+                                reply: {
+                                    messageReference:
+                                        typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                            ? this.messageId
+                                            : undefined,
+                                    failIfNotExists: false
+                                }
+                            })
+                            .catch(() => {});
                     }
 
                     while (formattedWinners.length >= 2000) {
-                        await channel.send({
-                            content: formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
-                            allowedMentions: this.allowedMentions
-                        });
+                        await channel
+                            .send({
+                                content: formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999)) + ',',
+                                allowedMentions: this.allowedMentions
+                            })
+                            .catch(() => {});
                         formattedWinners = formattedWinners.slice(
                             formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 1999) + 2).length
                         );
                     }
-                    channel.send({ content: formattedWinners, allowedMentions: this.allowedMentions });
+                    await channel
+                        .send({ content: formattedWinners, allowedMentions: this.allowedMentions })
+                        .catch(() => {});
 
                     const lastContentPart = congratMessage.slice(congratMessage.indexOf('{winners}') + 9);
                     if (lastContentPart.length) {
-                        channel.send({
-                            content: lastContentPart,
-                            components:
-                                options.messages.congrat.embed && typeof options.messages.congrat.embed === 'object'
-                                    ? null
-                                    : components,
-                            allowedMentions: this.allowedMentions
-                        });
+                        await channel
+                            .send({
+                                content: lastContentPart,
+                                components:
+                                    options.messages.congrat.embed && typeof options.messages.congrat.embed === 'object'
+                                        ? null
+                                        : components,
+                                allowedMentions: this.allowedMentions
+                            })
+                            .catch(() => {});
                     }
                 }
 
@@ -989,29 +1019,13 @@ class Giveaway extends EventEmitter {
                     if (message?.length > 2000) formattedWinners = winners.map((w) => `<@${w.id}>`).join(', ');
                     const embed = this.fillInEmbed(options.messages.congrat.embed);
                     const embedDescription = embed.description?.replace('{winners}', formattedWinners) ?? '';
+
                     if (embedDescription.length <= 4096) {
-                        channel.send({
-                            content: message?.length <= 2000 ? message : null,
-                            embeds: [embed.setDescription(embedDescription)],
-                            components,
-                            allowedMentions: this.allowedMentions,
-                            reply: {
-                                messageReference:
-                                    !(message?.length > 2000) &&
-                                    typeof options.messages.congrat.replyToGiveaway === 'boolean'
-                                        ? this.messageId
-                                        : undefined,
-                                failIfNotExists: false
-                            }
-                        });
-                    } else {
-                        const firstEmbed = new Discord.MessageEmbed(embed).setDescription(
-                            embed.description.slice(0, embed.description.indexOf('{winners}'))
-                        );
-                        if (firstEmbed.length) {
-                            channel.send({
+                        await channel
+                            .send({
                                 content: message?.length <= 2000 ? message : null,
-                                embeds: [firstEmbed],
+                                embeds: [embed.setDescription(embedDescription)],
+                                components,
                                 allowedMentions: this.allowedMentions,
                                 reply: {
                                     messageReference:
@@ -1021,66 +1035,97 @@ class Giveaway extends EventEmitter {
                                             : undefined,
                                     failIfNotExists: false
                                 }
-                            });
+                            })
+                            .catch(() => {});
+                    } else {
+                        const firstEmbed = new Discord.MessageEmbed(embed).setDescription(
+                            embed.description.slice(0, embed.description.indexOf('{winners}'))
+                        );
+                        if (firstEmbed.length) {
+                            await channel
+                                .send({
+                                    content: message?.length <= 2000 ? message : null,
+                                    embeds: [firstEmbed],
+                                    allowedMentions: this.allowedMentions,
+                                    reply: {
+                                        messageReference:
+                                            !(message?.length > 2000) &&
+                                            typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                                ? this.messageId
+                                                : undefined,
+                                        failIfNotExists: false
+                                    }
+                                })
+                                .catch(() => {});
                         }
 
                         const tempEmbed = new Discord.MessageEmbed().setColor(embed.color);
                         while (formattedWinners.length >= 4096) {
-                            await channel.send({
-                                embeds: [
-                                    tempEmbed.setDescription(
-                                        formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095)) + ','
-                                    )
-                                ],
-                                allowedMentions: this.allowedMentions
-                            });
+                            await channel
+                                .send({
+                                    embeds: [
+                                        tempEmbed.setDescription(
+                                            formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095)) + ','
+                                        )
+                                    ],
+                                    allowedMentions: this.allowedMentions
+                                })
+                                .catch(() => {});
                             formattedWinners = formattedWinners.slice(
                                 formattedWinners.slice(0, formattedWinners.lastIndexOf(',', 4095) + 2).length
                             );
                         }
-                        channel.send({
-                            embeds: [tempEmbed.setDescription(formattedWinners)],
-                            allowedMentions: this.allowedMentions
-                        });
+                        await channel
+                            .send({
+                                embeds: [tempEmbed.setDescription(formattedWinners)],
+                                allowedMentions: this.allowedMentions
+                            })
+                            .catch(() => {});
 
                         const lastEmbed = tempEmbed.setDescription(
                             embed.description.slice(embed.description.indexOf('{winners}') + 9)
                         );
                         if (lastEmbed.length) {
-                            channel.send({ embeds: [lastEmbed], components, allowedMentions: this.allowedMentions });
+                            await channel
+                                .send({ embeds: [lastEmbed], components, allowedMentions: this.allowedMentions })
+                                .catch(() => {});
                         }
                     }
                 } else if (message?.length <= 2000) {
-                    channel.send({
-                        content: message,
-                        components,
-                        allowedMentions: this.allowedMentions,
-                        reply: {
-                            messageReference:
-                                typeof options.messages.congrat.replyToGiveaway === 'boolean'
-                                    ? this.messageId
-                                    : undefined,
-                            failIfNotExists: false
-                        }
-                    });
+                    await channel
+                        .send({
+                            content: message,
+                            components,
+                            allowedMentions: this.allowedMentions,
+                            reply: {
+                                messageReference:
+                                    typeof options.messages.congrat.replyToGiveaway === 'boolean'
+                                        ? this.messageId
+                                        : undefined,
+                                failIfNotExists: false
+                            }
+                        })
+                        .catch(() => {});
                 }
                 resolve(winners);
             } else {
                 if (options.messages.replyWhenNoWinner !== false) {
                     const embed = this.fillInEmbed(options.messages.error.embed);
-                    channel.send({
-                        content: this.fillInString(options.messages.error.content || options.messages.error),
-                        embeds: embed ? [embed] : null,
-                        components: this.fillInComponents(options.messages.error.components),
-                        allowedMentions: this.allowedMentions,
-                        reply: {
-                            messageReference:
-                                typeof options.messages.error.replyToGiveaway === 'boolean'
-                                    ? this.messageId
-                                    : undefined,
-                            failIfNotExists: false
-                        }
-                    });
+                    await channel
+                        .send({
+                            content: this.fillInString(options.messages.error.content || options.messages.error),
+                            embeds: embed ? [embed] : null,
+                            components: this.fillInComponents(options.messages.error.components),
+                            allowedMentions: this.allowedMentions,
+                            reply: {
+                                messageReference:
+                                    typeof options.messages.error.replyToGiveaway === 'boolean'
+                                        ? this.messageId
+                                        : undefined,
+                                failIfNotExists: false
+                            }
+                        })
+                        .catch(() => {});
                 }
                 resolve([]);
             }

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -708,6 +708,11 @@ class Giveaway extends EventEmitter {
                     );
                 }
 
+                // Consider the ending successful if at least the embed was edited successfully
+                this.ended = true;
+                if (this.isDrop || this.endAt < this.client.readyTimestamp) this.endAt = Date.now();
+                await this.manager.editGiveaway(this.messageId, this.data);
+
                 let formattedWinners = winners.map((w) => `<@${w.id}>`).join(', ');
                 const winMessage = this.fillInString(this.messages.winMessage.content || this.messages.winMessage);
                 const message = winMessage?.replace('{winners}', formattedWinners);
@@ -833,22 +838,6 @@ class Giveaway extends EventEmitter {
                     });
                 }
             } else {
-                const message = this.fillInString(noWinnerMessage?.content || noWinnerMessage);
-                const embed = this.fillInEmbed(noWinnerMessage?.embed);
-                if (message || embed) {
-                    channel.send({
-                        content: message,
-                        embeds: embed ? [embed] : null,
-                        components: this.fillInComponents(noWinnerMessage?.components),
-                        allowedMentions: this.allowedMentions,
-                        reply: {
-                            messageReference:
-                                typeof noWinnerMessage?.replyToGiveaway === 'boolean' ? this.messageId : undefined,
-                            failIfNotExists: false
-                        }
-                    });
-                }
-
                 const date = Date.now();
                 do {
                     const message = await this.message
@@ -869,14 +858,30 @@ class Giveaway extends EventEmitter {
                             'could not get edited. Try later!'
                     );
                 }
+
+                // Consider the ending successful if at least the embed was edited successfully
+                this.ended = true;
+                if (this.isDrop || this.endAt < this.client.readyTimestamp) this.endAt = Date.now();
+                await this.manager.editGiveaway(this.messageId, this.data);
+
+                const message = this.fillInString(noWinnerMessage?.content || noWinnerMessage);
+                const embed = this.fillInEmbed(noWinnerMessage?.embed);
+                if (message || embed) {
+                    channel.send({
+                        content: message,
+                        embeds: embed ? [embed] : null,
+                        components: this.fillInComponents(noWinnerMessage?.components),
+                        allowedMentions: this.allowedMentions,
+                        reply: {
+                            messageReference:
+                                typeof noWinnerMessage?.replyToGiveaway === 'boolean' ? this.messageId : undefined,
+                            failIfNotExists: false
+                        }
+                    });
+                }
             }
 
-            // Consider the ending successful if at least the embed was edited successfully
-            this.ended = true;
-            if (this.isDrop || this.endAt < this.client.readyTimestamp) this.endAt = Date.now();
-            await this.manager.editGiveaway(this.messageId, this.data);
             this.isEnding = false;
-
             resolve(winners);
         });
     }


### PR DESCRIPTION
## Changes
<!-- Describe what changes this PR includes and explain why are they needed. -->
Added private `isEnding` property which makes sure that `ended` is only true if the giveaway embed was successfully edited.

The only thing that isn't checked is wheter all win Messages were sent. But checking that would require too much fetching, so it's not worth it. It's most important that the embed is properly edited.

## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.