### PR TITLE
fillInEmbed: fix data source of embed

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -229,6 +229,7 @@ exports.GiveawayEditOptions = {};
  * @property {Discord.Snowflake} guildId The Id of the guild.
  * @property {Discord.Snowflake[]} [winnerIds] The winner Ids of the giveaway after it ended.
  * @property {Discord.Snowflake} messageId The Id of the message.
+ * @property {Discord.Snowflake} endMessageId The Id of the message of ended giveaway.
  * @property {Discord.EmojiIdentifierResolvable} [reaction] The reaction to participate in the giveaway.
  * @property {boolean} [botsCanWin] If bots can win the giveaway.
  * @property {Discord.PermissionResolvable[]} [exemptPermissions] Members with any of these permissions will not be able to win the giveaway.

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -377,7 +377,7 @@ class Giveaway extends EventEmitter {
      */
     fillInEmbed(embed) {
         if (!embed || typeof embed !== 'object') return null;
-        embed = Discord.EmbedBuilder.from(embed);
+        embed = Discord.EmbedBuilder.from(embed.data);
         embed.setTitle(this.fillInString(embed.data.title));
         embed.setDescription(this.fillInString(embed.data.description));
         if (typeof embed.data.author?.name === 'string')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -252,6 +252,7 @@ export interface GiveawayData<ExtraData = any> {
     ended: boolean;
     winnerIds?: Snowflake[];
     messageId: Snowflake;
+    endMessageId: Snowflake;
     reaction?: EmojiIdentifierResolvable;
     exemptPermissions?: PermissionResolvable[];
     exemptMembers?: string;


### PR DESCRIPTION
<!--

**Before submitting your PR!**

- Select "develop" as the base branch.
- Give your PR a easy to understand title.

-->

## Changes
Since we shifted using discordjs v14, `EmbedBuilder` uses a `data` property to access the properties of the embed. 
The `Discord.EmbedBuilder.from` method accepts the same parameter with `APIEmbed` [interface](https://discord-api-types.dev/api/discord-api-types-v10/interface/APIEmbed) but we're currently passing the embed instance to the said function, this results to have a redundant `data` property. Giving `{data: {data:{}}}` structure. It happens when we pull data from a database.

When a giveaway ended. The line https://github.com/Androz2091/discord-giveaways/blob/master/src/Giveaway.js#L751 throws an error. Because the description is null coming from https://github.com/Androz2091/discord-giveaways/blob/master/src/Giveaway.js#L745-L746. Again it only happens when pulling the giveaway from DB where the timer runs out but has not ended.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes (JSDoc, README or typings), no code change.
- [ ] This PR introduces some breaking changes.