### PR TITLE
✨ Button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,25 @@ client.giveawaysManager.reroll(messageId, {
 You can [access giveaway properties](https://github.com/Androz2091/discord-giveaways#access-giveaway-properties-in-messages) in these messages.  
 [Message options](https://github.com/Androz2091/discord-giveaways#message-options) are available in these messages.
 
+## Buttons instead of reaction
+
+```js
+// Requires Manager from discord-giveaways
+const { GiveawaysManager } = require('discord-giveaways');
+const manager = new GiveawaysManager(client, {
+    storage: './giveaways.json',
+    default: {
+        botsCanWin: false,
+        embedColor: '#FF0000',
+        embedColorEnd: '#000000',
+        buttons: {
+            join: new Discord.ButtonBuilder().setLabel('Join').setStyle('PRIMARY').setCustomId('123'),
+            leave: new Discord.ButtonBuilder().setLabel('Leave').setStyle('SECONDARY').setCustomId('1234')
+        }
+    }
+});
+```
+
 ## Custom Database
 
 You can use your custom database to save giveaways, instead of the json files (the "database" by default for `discord-giveaways`).  

--- a/README.md
+++ b/README.md
@@ -521,8 +521,14 @@ const manager = new GiveawaysManager(client, {
         embedColor: '#FF0000',
         embedColorEnd: '#000000',
         buttons: {
-            join: new Discord.ButtonBuilder().setLabel('Join').setStyle('PRIMARY').setCustomId('123'),
-            leave: new Discord.ButtonBuilder().setLabel('Leave').setStyle('SECONDARY').setCustomId('1234')
+            join: new Discord.ButtonBuilder()
+                .setLabel('Join')
+                .setStyle(Discord.ButtonStyle.Primary)
+                .setCustomId('123'),
+            leave: new Discord.ButtonBuilder()
+                .setLabel('Leave')
+                .setStyle(Discord.ButtonStyle.Secondary)
+                .setCustomId('1234')
         }
     }
 });

--- a/README.md
+++ b/README.md
@@ -531,10 +531,13 @@ const manager = new GiveawaysManager(client, {
 });
 ```
 
--   **options.default.buttons.join**: the button to join the giveaway.
--   **options.default.buttons.leave**: the button to leave the giveaway. If not set, the join-button doubles as the leave-button
--   **options.default.buttons.joinReply**: sent in the channel as the ephemeral interaction reply to the join-button. If set to "null", custom behaviour can be added via the [event](https://discord-giveaways.js.org/GiveawaysManager.html#event:giveawayJoined).
--   **options.default.buttons.leaveReply**: sent in the channel as the ephemeral interaction reply to the leave-button. If set to "null", custom behaviour can be added via the [event](https://discord-giveaways.js.org/GiveawaysManager.html#event:giveawayLeft).
+-   **options.default.buttons.join**: the button to join giveaways.
+-   **options.default.buttons.leave**: the button to leave giveaways.  
+    ^^^ If not set, the join-button doubles as the leave-button.
+-   **options.default.buttons.joinReply**: sent in the channel as the ephemeral interaction reply to the join-button.  
+    ^^^ If set to `null`, custom behaviour can be added via the [event](https://discord-giveaways.js.org/GiveawaysManager.html#event:giveawayJoined).
+-   **options.default.buttons.leaveReply**: sent in the channel as the ephemeral interaction reply to the leave-button.  
+    ^^^ If set to `null`, custom behaviour can be added via the [event](https://discord-giveaways.js.org/GiveawaysManager.html#event:giveawayLeft).
 
 You can [access other giveaway properties](https://github.com/Androz2091/discord-giveaways#access-giveaway-properties-in-messages) in these properties.  
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Discord Giveaways is a powerful [Node.js](https://nodejs.org) module that allows
 -   📁 Support for all databases! (default is json)
 -   ⚙️ Very customizable! (prize, duration, winners, ignored permissions, bonus entries, etc...)
 -   🚀 Super powerful: start, edit, reroll, end, delete and pause giveaways!
--   💥 Events: giveawayEnded, giveawayRerolled, giveawayDeleted, giveawayReactionAdded, giveawayReactionRemoved, endedGiveawayReactionAdded
--   🕸️ Support for shards!
+-   💥 Events: giveawayEnded, giveawayRerolled, giveawayDeleted, giveawayMemberJoined, giveawayMemberLeft
+-   🕸️ Support for buttons and shards!
 -   and much more!
 
 ## Installation
@@ -521,11 +521,11 @@ const manager = new GiveawaysManager(client, {
             join: new Discord.ButtonBuilder()
                 .setLabel('Join')
                 .setStyle(Discord.ButtonStyle.Primary)
-                .setCustomId('123'),
+                .setCustomId('join'),
             leave: new Discord.ButtonBuilder()
                 .setLabel('Leave')
                 .setStyle(Discord.ButtonStyle.Secondary)
-                .setCustomId('1234')
+                .setCustomId('leave')
         }
     }
 });

--- a/README.md
+++ b/README.md
@@ -512,14 +512,11 @@ You can [access giveaway properties](https://github.com/Androz2091/discord-givea
 ## Buttons instead of reaction
 
 ```js
-// Requires Manager from discord-giveaways
+const Discord = require('discord.js');
 const { GiveawaysManager } = require('discord-giveaways');
 const manager = new GiveawaysManager(client, {
     storage: './giveaways.json',
     default: {
-        botsCanWin: false,
-        embedColor: '#FF0000',
-        embedColorEnd: '#000000',
         buttons: {
             join: new Discord.ButtonBuilder()
                 .setLabel('Join')
@@ -533,6 +530,13 @@ const manager = new GiveawaysManager(client, {
     }
 });
 ```
+
+-   **options.default.buttons.join**: the button to join the giveaway.
+-   **options.default.buttons.leave**: the button to leave the giveaway. If not set, the join-button doubles as the leave-button
+-   **options.default.buttons.joinReply**: sent in the channel as the ephemeral interaction reply to the join-button. If set to "null", custom behaviour can be added via the [event](https://discord-giveaways.js.org/GiveawaysManager.html#event:giveawayJoined).
+-   **options.default.buttons.leaveReply**: sent in the channel as the ephemeral interaction reply to the leave-button. If set to "null", custom behaviour can be added via the [event](https://discord-giveaways.js.org/GiveawaysManager.html#event:giveawayLeft).
+
+You can [access other giveaway properties](https://github.com/Androz2091/discord-giveaways#access-giveaway-properties-in-messages) in these properties.  
 
 ## Custom Database
 

--- a/examples/custom-databases/mongoose.js
+++ b/examples/custom-databases/mongoose.js
@@ -44,6 +44,13 @@ const giveawaySchema = new mongoose.Schema(
         hostedBy: String,
         winnerIds: { type: [String], default: undefined },
         reaction: mongoose.Mixed,
+        buttons: {
+            join: mongoose.Mixed,
+            leave: mongoose.Mixed,
+            joinReply: mongoose.Mixed,
+            leaveReply: mongoose.Mixed
+        },
+        entrantIds: { type: [String], default: undefined },
         botsCanWin: Boolean,
         embedColor: mongoose.Mixed,
         embedColorEnd: mongoose.Mixed,

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.version = require('./package.json').version;
 exports.GiveawaysManager = require('./src/Manager');
 exports.Giveaway = require('./src/Giveaway');
+exports.Events = require('./src/Events');

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -62,6 +62,13 @@ exports.GiveawayMessages = {
  */
 
 /**
+ * @typedef {Object} ButtonsObject
+ * 
+ * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} join The button to join the giveaway.
+ * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} [leave] The button to leave the giveaway.
+ */
+
+/**
  * The start options for new giveaways.
  * @typedef GiveawayStartOptions
  *
@@ -76,6 +83,7 @@ exports.GiveawayMessages = {
  * @property {Discord.ColorResolvable} [embedColor] The color of the giveaway embed when it is running.
  * @property {Discord.ColorResolvable} [embedColorEnd] The color of the giveaway embed when it has ended.
  * @property {Discord.EmojiIdentifierResolvable} [reaction] The reaction to participate in the giveaway.
+ * @property {ButtonsObject} [buttons] The buttons for the giveaway.
  * @property {GiveawayMessages} [messages] The giveaway messages.
  * @property {string} [thumbnail] The URL appearing as the thumbnail on the giveaway embed.
  * @property {string} [image] The URL appearing as the image on the giveaway embed.
@@ -155,6 +163,7 @@ exports.PauseOptions = {
  * @property {Discord.ColorResolvable} [default.embedColorEnd='#000000'] The color of the giveaway embeds when they have ended.
  * @property {Discord.EmojiIdentifierResolvable} [default.reaction='🎉'] The reaction to participate in giveaways.
  * @property {LastChanceOptions} [default.lastChance] The options for the last chance system.
+ * @property {ButtonsObject} [default.buttons] The buttons for the giveaways.
  */
 exports.GiveawaysManagerOptions = {
     storage: './giveaways.json',
@@ -211,6 +220,7 @@ exports.GiveawayRerollOptions = {
  * @property {BonusEntry[]} [newBonusEntries] The new BonusEntry objects.
  * @property {ExemptMembersFunction} [newExemptMembers] The new filter function to exempt members from winning the giveaway.
  * @property {LastChanceOptions} [newLastChance] The new options for the last chance system.<br>Will get merged with the existing object, if there.
+ * @property {ButtonsObject} [newButtons] The new buttons for the giveaway.
  */
 exports.GiveawayEditOptions = {};
 
@@ -231,6 +241,7 @@ exports.GiveawayEditOptions = {};
  * @property {Discord.Snowflake[]} [winnerIds] The winner Ids of the giveaway after it ended.
  * @property {Discord.Snowflake} messageId The Id of the message.
  * @property {Discord.EmojiIdentifierResolvable} [reaction] The reaction to participate in the giveaway.
+ * @property {ButtonsObject} [buttons] The buttons for the giveaway.
  * @property {boolean} [botsCanWin] If bots can win the giveaway.
  * @property {Discord.PermissionResolvable[]} [exemptPermissions] Members with any of these permissions will not be able to win the giveaway.
  * @property {string} [exemptMembers] Filter function to exempt members from winning the giveaway.
@@ -243,5 +254,6 @@ exports.GiveawayEditOptions = {};
  * @property {PauseOptions} [pauseOptions] The options for the pause system.
  * @property {boolean} [isDrop] If the giveaway is a drop, or not.<br>Drop means that if the amount of valid entrants to the giveaway is the same as "winnerCount" then it immediately ends.
  * @property {Discord.MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the giveaway messages content.
+ * @property {Snowflake[]} [entrantIds] The entrant ids for this giveaway, if buttons are used.
  */
 exports.GiveawayData = {};

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -63,7 +63,7 @@ exports.GiveawayMessages = {
 
 /**
  * @typedef {Object} ButtonsObject
- * 
+ *
  * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} join The button to join the giveaway.
  * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} [leave] The button to leave the giveaway.
  */
@@ -153,8 +153,8 @@ exports.PauseOptions = {
  * @typedef GiveawaysManagerOptions
  *
  * @property {string} [storage='./giveaways.json'] The storage path for the giveaways.
- * @property {number} [forceUpdateEvery=null] Force the giveaway messages to be updated at a specific interval.
- * @property {number} [endedGiveawaysLifetime=null] The number of milliseconds after which ended giveaways should get deleted from the DB.<br>⚠ Giveaways deleted from the DB cannot get rerolled anymore!
+ * @property {?number} [forceUpdateEvery=null] Force the giveaway messages to be updated at a specific interval.
+ * @property {?number} [endedGiveawaysLifetime=null] The number of milliseconds after which ended giveaways should get deleted from the DB.<br>⚠ Giveaways deleted from the DB cannot get rerolled anymore!
  * @property {Object} [default] The default options for new giveaways.
  * @property {boolean} [default.botsCanWin=false] If bots can win giveaways.
  * @property {Discord.PermissionResolvable[]} [default.exemptPermissions=[]] Members with any of these permissions won't be able to win a giveaway.
@@ -163,7 +163,7 @@ exports.PauseOptions = {
  * @property {Discord.ColorResolvable} [default.embedColorEnd='#000000'] The color of the giveaway embeds when they have ended.
  * @property {Discord.EmojiIdentifierResolvable} [default.reaction='🎉'] The reaction to participate in giveaways.
  * @property {LastChanceOptions} [default.lastChance] The options for the last chance system.
- * @property {ButtonsObject} [default.buttons] The buttons for the giveaways.
+ * @property {?ButtonsObject} [default.buttons=null] The buttons for the giveaways.
  */
 exports.GiveawaysManagerOptions = {
     storage: './giveaways.json',
@@ -176,7 +176,7 @@ exports.GiveawaysManagerOptions = {
         embedColor: '#FF0000',
         embedColorEnd: '#000000',
         reaction: '🎉',
-        buttons: { join: null, leave: null },
+        buttons: null,
         lastChance: {
             enabled: false,
             content: '⚠️ **LAST CHANCE TO ENTER !** ⚠️',

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -167,6 +167,7 @@ exports.GiveawaysManagerOptions = {
         embedColor: '#FF0000',
         embedColorEnd: '#000000',
         reaction: '🎉',
+        buttons: { join: null, leave: null },
         lastChance: {
             enabled: false,
             content: '⚠️ **LAST CHANCE TO ENTER !** ⚠️',

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -54,18 +54,20 @@ exports.GiveawayMessages = {
  */
 
 /**
+ * @typedef {Object} ButtonsObject
+ *
+ * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} join The button to join the giveaway.
+ * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} [leave] The button to leave the giveaway.
+ * @property {?(string|MessageObject)} [joinReply] Sent in the channel as the ephemeral interaction reply to the join-button.
+ * @property {?(string|MessageObject)} [leaveReply] Sent in the channel as the ephemeral interaction reply to the leave-button.
+ */
+
+/**
  * @typedef {Function} ExemptMembersFunction
  *
  * @param {Discord.GuildMember} member
  * @param {Giveaway} giveaway
  * @returns {Promise<boolean>|boolean}
- */
-
-/**
- * @typedef {Object} ButtonsObject
- *
- * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} join The button to join the giveaway.
- * @property {Discord.JSONEncodable<Discord.APIButtonComponent>|Discord.APIButtonComponent} [leave] The button to leave the giveaway.
  */
 
 /**
@@ -134,9 +136,9 @@ exports.LastChanceOptions = {
  *
  * @property {boolean} [isPaused=false] If the giveaway is paused.
  * @property {string} [content='⚠️ **THIS GIVEAWAY IS PAUSED !** ⚠️'] The text of the embed when the giveaway is paused.
- * @property {number} [unpauseAfter=null] The number of milliseconds, or a timestamp in milliseconds, after which the giveaway will automatically unpause.
+ * @property {?number} [unpauseAfter=null] The number of milliseconds, or a timestamp in milliseconds, after which the giveaway will automatically unpause.
  * @property {Discord.ColorResolvable} [embedColor='#FFFF00'] The color of the embed when the giveaway is paused.
- * @private @property {number} [durationAfterPause=null|giveaway.remainingTime] The remaining duration after the giveaway is unpaused.<br>⚠ This property gets set by the manager so that the pause system works properly. It is not recommended to set it manually!
+ * @private @property {?number} [durationAfterPause=null|giveaway.remainingTime] The remaining duration after the giveaway is unpaused.<br>⚠ This property gets set by the manager so that the pause system works properly. It is not recommended to set it manually!
  * @property {string} [infiniteDurationText='`NEVER`'] The text that gets displayed next to "GiveawayMessages#drawing" in the paused embed, when there is no "unpauseAfter".
  */
 exports.PauseOptions = {
@@ -161,9 +163,11 @@ exports.PauseOptions = {
  * @property {ExemptMembersFunction} [default.exemptMembers] Function to filter members.<br>If true is returned, the member won't be able to win a giveaway.
  * @property {Discord.ColorResolvable} [default.embedColor='#FF0000'] The color of the giveaway embeds when they are running.
  * @property {Discord.ColorResolvable} [default.embedColorEnd='#000000'] The color of the giveaway embeds when they have ended.
- * @property {Discord.EmojiIdentifierResolvable} [default.reaction='🎉'] The reaction to participate in giveaways.
+ * @property {?Discord.EmojiIdentifierResolvable} [default.reaction='🎉'] The reaction to participate in giveaways.
  * @property {LastChanceOptions} [default.lastChance] The options for the last chance system.
- * @property {ButtonsObject} [default.buttons=null] The buttons for the giveaways.
+ * @property {?ButtonsObject} [default.buttons] The buttons for the giveaways.
+ * @property {?(string|MessageObject)} [default.buttons.joinReply='✅ joined'] Sent in the channel as the ephemeral interaction reply to the join-button.
+ * @property {?(string|MessageObject)} [default.buttons.leaveReply='✅ left'] Sent in the channel as the ephemeral interaction reply to the leave-button.
  */
 exports.GiveawaysManagerOptions = {
     storage: './giveaways.json',
@@ -176,7 +180,10 @@ exports.GiveawaysManagerOptions = {
         embedColor: '#FF0000',
         embedColorEnd: '#000000',
         reaction: '🎉',
-        buttons: null,
+        buttons: {
+            joinReply: '✅ joined',
+            leaveReply: '✅ left'
+        },
         lastChance: {
             enabled: false,
             content: '⚠️ **LAST CHANCE TO ENTER !** ⚠️',

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -163,7 +163,7 @@ exports.PauseOptions = {
  * @property {Discord.ColorResolvable} [default.embedColorEnd='#000000'] The color of the giveaway embeds when they have ended.
  * @property {Discord.EmojiIdentifierResolvable} [default.reaction='🎉'] The reaction to participate in giveaways.
  * @property {LastChanceOptions} [default.lastChance] The options for the last chance system.
- * @property {?ButtonsObject} [default.buttons=null] The buttons for the giveaways.
+ * @property {ButtonsObject} [default.buttons=null] The buttons for the giveaways.
  */
 exports.GiveawaysManagerOptions = {
     storage: './giveaways.json',

--- a/src/Events.js
+++ b/src/Events.js
@@ -1,0 +1,121 @@
+/**
+ * @typedef {Object} Events
+ * @property {string} EndedGiveawayReactionAdded endedGiveawayReactionAdded
+ * @property {string} GiveawayDeleted giveawayDeleted'
+ * @property {string} GiveawayEnded giveawayEnded
+ * @property {string} GiveawayMemberJoined giveawayMemberJoined
+ * @property {string} GiveawayMemberLeft giveawayMemberLeft
+ * @property {string} GiveawayRerolled giveawayRerolled
+ */
+
+// JSDoc for IntelliSense purposes
+/**
+ * @type {Events}
+ * @ignore
+ */
+module.exports = {
+    EndedGiveawayReactionAdded: 'endedGiveawayReactionAdded',
+    GiveawayDeleted: 'giveawayDeleted',
+    GiveawayEnded: 'giveawayEnded',
+    GiveawayMemberJoined: 'giveawayMemberJoined',
+    GiveawayMemberLeft: 'giveawayMemberLeft',
+    GiveawayRerolled: 'giveawayRerolled'
+};
+
+/**
+ * Emitted when someone reacted to an ended giveaway.
+ * @event GiveawaysManager#endedGiveawayReactionAdded
+ * @param {Giveaway} giveaway The giveaway instance
+ * @param {Discord.GuildMember} member The member who reacted to the ended giveaway
+ * @param {Discord.MessageReaction} reaction The reaction object
+ *
+ * @example
+ * // This can be used to prevent new participants when giveaways with reactions get rerolled
+ * manager.on('endedGiveawayReactionAdded', (giveaway, member, reaction) => {
+ *      return reaction.users.remove(member.user);
+ * });
+ */
+
+/**
+ * Emitted when a giveaway was deleted.
+ * @event GiveawaysManager#giveawayDeleted
+ * @param {Giveaway} giveaway The giveaway instance
+ *
+ * @example
+ * // This can be used to add logs
+ * manager.on('giveawayDeleted', (giveaway) => {
+ *      console.log('Giveaway with message Id ' + giveaway.messageId + ' was deleted.')
+ * });
+ */
+
+/**
+ * Emitted when a giveaway ended.
+ * @event GiveawaysManager#giveawayEnded
+ * @param {Giveaway} giveaway The giveaway instance
+ * @param {Discord.GuildMember[]} winners The giveaway winners
+ *
+ * @example
+ * // This can be used to add features such as a congratulatory message in DM
+ * manager.on('giveawayEnded', (giveaway, winners) => {
+ *      winners.forEach((member) => {
+ *          member.send('Congratulations, ' + member.user.username + ', you won: ' + giveaway.prize);
+ *      });
+ * });
+ */
+
+/**
+ * Emitted when someone joined a giveaway.
+ * @event GiveawaysManager#giveawayMemberJoined
+ * @param {Giveaway} giveaway The giveaway instance
+ * @param {Discord.GuildMember} member The member who joined the giveaway
+ * @param {Discord.MessageReaction|Discord.ButtonInteraction} interaction The reaction to enter the giveaway
+ *
+ * @example
+ * // This can be used to add features such as giveaway requirements
+ * // Best used with the "exemptMembers" property of the giveaways
+ * manager.on('giveawayMemberJoined', (giveaway, member, reaction) => {
+ *     if (!member.roles.cache.get('123456789')) {
+ *          const index = giveaway.entrantIds.indexOf(member.id);
+            giveaway.entrantIds.splice(index, 1);
+ *          member.send('You must have this role to participate in the giveaway: Staff');
+ *     }
+ * });
+ * @example
+ * // This can be used to add features such as giveaway requirements
+ * // Best used with the "exemptMembers" property of the giveaways
+ * manager.on('giveawayMemberJoined', (giveaway, member, reaction) => {
+ *     if (!member.roles.cache.get('123456789')) {
+ *          reaction.users.remove(member.user);
+ *          member.send('You must have this role to participate in the giveaway: Staff');
+ *     }
+ * });
+ */
+
+/**
+ * Emitted when someone left a giveaway.
+ * @event GiveawaysManager#giveawayMemberLeft
+ * @param {Giveaway} giveaway The giveaway instance
+ * @param {Discord.GuildMember} member The member who remove their reaction giveaway
+ * @param {Discord.MessageReaction} reaction The reaction to enter the giveaway
+ *
+ * @example
+ * // This can be used to add features such as a leave message in DM
+ * manager.on('giveawayMemberLeft', (giveaway, member, interaction) => {
+ *      return member.send('That\'s sad, you won\'t be able to win the super cookie!');
+ * });
+ */
+
+/**
+ * Emitted when a giveaway was rerolled.
+ * @event GiveawaysManager#giveawayRerolled
+ * @param {Giveaway} giveaway The giveaway instance
+ * @param {Discord.GuildMember[]} winners The winners of the giveaway
+ *
+ * @example
+ * // This can be used to add features such as a congratulatory message per DM
+ * manager.on('giveawayRerolled', (giveaway, winners) => {
+ *      winners.forEach((member) => {
+ *          member.send('Congratulations, ' + member.user.username + ', you won: ' + giveaway.prize);
+ *      });
+ * });
+ */

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -679,6 +679,7 @@ class Giveaway extends EventEmitter {
             if (options.newLastChance && typeof options.newLastChance === 'object' && !this.isDrop) {
                 this.options.lastChance = deepmerge(this.options.lastChance || {}, options.newLastChance);
             }
+            if (this.newButtons?.join && this.buttons) this.buttons = this.newButtons;
 
             await this.manager.editGiveaway(this.messageId, this.data);
             if (this.remainingTime <= 0) this.manager.end(this.messageId).catch(() => {});

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -265,7 +265,7 @@ class Giveaway extends EventEmitter {
 
     /**
      * If the giveaway is a drop, or not.
-     * Drop means that if the amount of valid entrantIds to the giveaway is the same as "winnerCount" then it immediately ends.
+     * Drop means that if the amount of valid entrants to the giveaway is the same as "winnerCount" then it immediately ends.
      * @type {boolean}
      */
     get isDrop() {

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -332,7 +332,7 @@ class Giveaway extends EventEmitter {
                     ? this.options.bonusEntries || undefined
                     : serialize(this.options.bonusEntries),
             reaction: this.options.reaction,
-            buttons: this.options.buttons.join ? this.options.buttons : undefined,
+            buttons: this.options.buttons ? this.options.buttons : undefined,
             winnerIds: this.winnerIds.length ? this.winnerIds : undefined,
             extraData: this.extraData,
             lastChance: this.options.lastChance,

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -354,7 +354,9 @@ class Giveaway extends EventEmitter {
                     ? this.options.bonusEntries || undefined
                     : serialize(this.options.bonusEntries),
             reaction: this.options.reaction,
-            buttons: this.buttons ?? undefined,
+            buttons: this.buttons
+                ? Object.fromEntries(Object.entries(this.buttons).filter(([_, v]) => v !== null))
+                : undefined,
             winnerIds: this.winnerIds.length ? this.winnerIds : undefined,
             extraData: this.extraData,
             lastChance: this.options.lastChance,

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -132,7 +132,7 @@ class Giveaway extends EventEmitter {
          * The entrant ids for this giveaway, if buttons are used.
          * @type {?Discord.Snowflake[]}
          */
-        this.entrantIds = options.entrantIds ?? this.buttons ? [] : null;
+        this.entrantIds = options.entrantIds ?? (this.buttons ? [] : null);
         /**
          * Giveaway options which need to be processed in a getter or function.
          * @type {Object}

--- a/src/Giveaway.js
+++ b/src/Giveaway.js
@@ -14,6 +14,7 @@ const {
     BonusEntry,
     PauseOptions,
     MessageObject,
+    ButtonsObject,
     DEFAULT_CHECK_INTERVAL
 } = require('./Constants.js');
 const GiveawaysManager = require('./Manager.js');
@@ -122,13 +123,34 @@ class Giveaway extends EventEmitter {
          * @type {Discord.MessageMentionOptions}
          */
         this.allowedMentions = options.allowedMentions;
-        this.buttons = options.buttons ?? null;
+        /**
+         * The buttons of the giveaway, if any.
+         * @type {?ButtonsObject}
+         */
+        this.buttons = options.buttons?.join ? options.buttons : null;
+        /**
+         * The entrant ids for this giveaway, if buttons are used.
+         * @type {?Discord.Snowflake[]}
+         */
         this.entrantIds = options.entrantIds ?? this.buttons ? [] : null;
         /**
-         * The giveaway data.
-         * @type {GiveawayData}
+         * Giveaway options which need to be processed in a getter or function.
+         * @type {Object}
+         * @property {Discord.EmojiIdentifierResolvable} [reaction] The reaction to participate in the giveaway.
+         * @property {boolean} [botsCanWin] If bots can win the giveaway.
+         * @property {Discord.PermissionResolvable[]} [exemptPermissions] Members with any of these permissions will not be able to win the giveaway.
+         * @property {string} [exemptMembers] Filter function to exempt members from winning the giveaway.
+         * @property {string} [bonusEntries] The array of BonusEntry objects for the giveaway.
+         * @property {Discord.ColorResolvable} [embedColor] The color of the giveaway embed when it is running.
+         * @property {Discord.ColorResolvable} [embedColorEnd] The color of the giveaway embed when it has ended.
+         * @property {LastChanceOptions} [lastChance] The options for the last chance system.
+         * @property {PauseOptions} [pauseOptions] The options for the pause system.
+         * @property {boolean} [isDrop] If the giveaway is a drop, or not.<br>Drop means that if the amount of valid entrants to the giveaway is the same as "winnerCount" then it immediately ends.
          */
-        this.options = options;
+        this.options = Object.keys(options).reduce((obj, key) => {
+            if (!Object.keys(this).includes(key)) obj[key] = options[key];
+            return obj;
+        }, {});
         /**
          * The message instance of the embed of this giveaway.
          * @type {?Discord.Message}
@@ -332,7 +354,7 @@ class Giveaway extends EventEmitter {
                     ? this.options.bonusEntries || undefined
                     : serialize(this.options.bonusEntries),
             reaction: this.options.reaction,
-            buttons: this.options.buttons ? this.options.buttons : undefined,
+            buttons: this.buttons ?? undefined,
             winnerIds: this.winnerIds.length ? this.winnerIds : undefined,
             extraData: this.extraData,
             lastChance: this.options.lastChance,

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -251,10 +251,7 @@ class GiveawaysManager extends EventEmitter {
                 thumbnail: typeof options.thumbnail === 'string' ? options.thumbnail : undefined,
                 image: typeof options.image === 'string' ? options.image : undefined,
                 reaction: Discord.resolvePartialEmoji(options.reaction) ? options.reaction : undefined,
-                buttons:
-                    !Discord.resolvePartialEmoji(options.reaction) && options.buttons?.join
-                        ? deepmerge(this.options.buttons ?? {}, options.buttons)
-                        : undefined,
+                buttons: deepmerge(this.options.buttons ?? {}, options.buttons ?? {}),
                 botsCanWin: typeof options.botsCanWin === 'boolean' ? options.botsCanWin : undefined,
                 exemptPermissions: Array.isArray(options.exemptPermissions) ? options.exemptPermissions : undefined,
                 exemptMembers: typeof options.exemptMembers === 'function' ? options.exemptMembers : undefined,

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -651,6 +651,7 @@ class GiveawaysManager extends EventEmitter {
             if (!member) return;
             const emoji = Discord.resolvePartialEmoji(giveaway.reaction);
             if (messageReaction.emoji.name !== emoji.name || messageReaction.emoji.id !== emoji.id) return;
+
             if (giveaway.ended) return this.emit('endedGiveawayReactionAdded', giveaway, member, messageReaction);
             this.emit('giveawayReactionAdded', giveaway, member, messageReaction);
 
@@ -666,6 +667,7 @@ class GiveawaysManager extends EventEmitter {
             if (!member) return;
             const emoji = Discord.resolvePartialEmoji(giveaway.reaction);
             if (messageReaction.emoji.name !== emoji.name || messageReaction.emoji.id !== emoji.id) return;
+
             this.emit('giveawayReactionAdded', giveaway, member, messageReaction);
         });
 
@@ -675,11 +677,13 @@ class GiveawaysManager extends EventEmitter {
             if (!giveaway) return;
             if (!interaction.guild?.available) return;
             if (!interaction.channel.viewable) return;
+
             if (giveaway.buttons.join?.customId === interaction.customId)
                 this.emit('giveawayJoined', giveaway, interaction.member, interaction);
             else if (giveaway.buttons.leave?.customId === interaction.customId)
                 this.emit('giveawayLeft', giveaway, interaction.member, interaction);
             else return;
+            
             giveaway.entrantIds.push(interaction.member.id);
 
             if (giveaway.isDrop && giveaway.entrantIds.length >= giveaway.winnerCount) await checkForDropEnd(giveaway);
@@ -693,9 +697,7 @@ class GiveawaysManager extends EventEmitter {
     async _init() {
         let rawGiveaways = await this.getAllGiveaways();
 
-        await (this.client.readyAt
-            ? Promise.resolve()
-            : new Promise((resolve) => this.client.once(Discord.Events.ClientReady, resolve)));
+        await (this.client.readyAt ? Promise.resolve() : new Promise((resolve) => this.client.once(Discord.Events.InteractionCreate, resolve)));
 
         // Filter giveaways for each shard
         if (this.client.shard && this.client.guilds.cache.size) {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -236,8 +236,8 @@ class GiveawaysManager extends EventEmitter {
                 return reject(`Both "options.reaction" and "options.buttons.join" are set.`);
             }
             if (
-                this.options.buttons?.join?.style === Discord.ButtonStyle.Link ||
-                this.options.buttons?.leave?.style === Discord.ButtonStyle.Link
+                options.buttons?.join?.style === Discord.ButtonStyle.Link ||
+                options.buttons?.leave?.style === Discord.ButtonStyle.Link
             ) {
                 return reject(`"options.buttons.join" or "options.buttons.leave" is a "Link" button.`);
             }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -235,6 +235,12 @@ class GiveawaysManager extends EventEmitter {
             if (Discord.resolvePartialEmoji(options.reaction) && this.options.buttons?.join) {
                 return reject(`Both "options.reaction" and "options.buttons.join" are set.`);
             }
+            if (
+                this.options.buttons?.join?.style === Discord.ButtonStyle.Link ||
+                this.options.buttons?.leave?.style === Discord.ButtonStyle.Link
+            ) {
+                return reject(`"options.buttons.join" or "options.buttons.leave" is a "Link" button.`);
+            }
 
             const giveaway = new Giveaway(this, {
                 startAt: Date.now(),

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -698,10 +698,14 @@ class GiveawaysManager extends EventEmitter {
             if (!interaction.guild?.available) return;
             if (!interaction.channel.viewable) return;
 
-            if (
-                giveaway.buttons.join?.customId === interaction.customId &&
-                !giveaway.entrantIds.includes(interaction.member.id)
-            ) {
+            if (giveaway.buttons.join?.customId === interaction.customId) {
+                // If only one button is used, remove the user if he has already joined
+                if (!giveaway.buttons.leave && giveaway.entrantIds.includes(interaction.member.id)) {
+                    const index = giveaway.entrantIds.indexOf(interaction.member.id);
+                    giveaway.entrantIds.splice(index, 1);
+                    return this.emit('giveawayLeft', giveaway, interaction.member, interaction);
+                }
+
                 giveaway.entrantIds.push(interaction.member.id);
                 this.emit('giveawayJoined', giveaway, interaction.member, interaction);
             } else if (

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -252,9 +252,7 @@ class GiveawaysManager extends EventEmitter {
                 image: typeof options.image === 'string' ? options.image : undefined,
                 reaction: Discord.resolvePartialEmoji(options.reaction) ? options.reaction : undefined,
                 buttons:
-                    !Discord.resolvePartialEmoji(this.options.defaults.reaction) &&
-                    !Discord.resolvePartialEmoji(options.reaction) &&
-                    options.buttons?.join
+                    !Discord.resolvePartialEmoji(options.reaction) && options.buttons?.join
                         ? deepmerge(this.options.buttons ?? {}, options.buttons)
                         : undefined,
                 botsCanWin: typeof options.botsCanWin === 'boolean' ? options.botsCanWin : undefined,
@@ -288,11 +286,9 @@ class GiveawaysManager extends EventEmitter {
                 embeds: [embed],
                 allowedMentions: giveaway.allowedMentions,
                 components: giveaway.buttons
-                    ? [
-                          new Discord.ActionRowBuilder().addComponents(
-                              giveaway.fillInComponents([giveaway.buttons.join, giveaway.buttons.leave])
-                          )
-                      ]
+                    ? giveaway.fillInComponents([
+                          { components: [giveaway.buttons.join, giveaway.buttons.leave].filter(Boolean) }
+                      ])
                     : undefined
             });
             giveaway.messageId = message.id;

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -676,7 +676,7 @@ class GiveawaysManager extends EventEmitter {
             const users = await giveaway.fetchAllEntrants().catch(() => {});
 
             let validUsers = 0;
-            for (const user of [...(users?.values() || [])]) {
+            for (const user of (users?.values() || [])) {
                 if (await giveaway.checkWinnerEntry(user)) validUsers++;
                 if (validUsers === giveaway.winnerCount) {
                     await this.end(giveaway.messageId).catch(() => {});

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -706,7 +706,7 @@ class GiveawaysManager extends EventEmitter {
 
         await (this.client.readyAt
             ? Promise.resolve()
-            : new Promise((resolve) => this.client.once(Discord.Events.InteractionCreate, resolve)));
+            : new Promise((resolve) => this.client.once(Discord.Events.ClientReady, resolve)));
 
         // Filter giveaways for each shard
         if (this.client.shard && this.client.guilds.cache.size) {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -765,6 +765,8 @@ class GiveawaysManager extends EventEmitter {
 
                 this.emit(Events.GiveawayMemberLeft, giveaway, interaction.member, interaction);
             }
+
+            await this.editGiveaway(giveaway.messageId, giveaway.data);
         });
     }
 

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -642,7 +642,7 @@ class GiveawaysManager extends EventEmitter {
             }
         };
 
-        this.client.on('messageReactionAdd', async (messageReaction, user) => {
+        this.client.on(Discord.Events.MessageReactionAdd, async (messageReaction, user) => {
             const giveaway = this.giveaways.find((g) => g.messageId === messageReaction.message.id);
             if (!giveaway) return;
             if (!messageReaction.message.guild?.available) return;
@@ -657,7 +657,7 @@ class GiveawaysManager extends EventEmitter {
             if (giveaway.isDrop && messageReaction.count - 1 >= giveaway.winnerCount) await checkForDropEnd(giveaway);
         });
 
-        this.client.on('messageReactionRemove', async (messageReaction, user) => {
+        this.client.on(Discord.Events.MessageReactionRemove, async (messageReaction, user) => {
             const giveaway = this.giveaways.find((g) => g.messageId === messageReaction.message.id);
             if (!giveaway) return;
             if (!messageReaction.message.guild?.available) return;
@@ -669,7 +669,7 @@ class GiveawaysManager extends EventEmitter {
             this.emit('giveawayReactionAdded', giveaway, member, messageReaction);
         });
 
-        this.client.on('interactionCreated', async (interaction) => {
+        this.client.on(Discord.Events.InteractionCreate, async (interaction) => {
             if (!interaction.isButton()) return;
             const giveaway = this.giveaways.find((g) => g.messageId === interaction.message.id);
             if (!giveaway) return;
@@ -693,7 +693,9 @@ class GiveawaysManager extends EventEmitter {
     async _init() {
         let rawGiveaways = await this.getAllGiveaways();
 
-        await (this.client.readyAt ? Promise.resolve() : new Promise((resolve) => this.client.once('ready', resolve)));
+        await (this.client.readyAt
+            ? Promise.resolve()
+            : new Promise((resolve) => this.client.once(Discord.Events.ClientReady, resolve)));
 
         // Filter giveaways for each shard
         if (this.client.shard && this.client.guilds.cache.size) {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -721,25 +721,25 @@ class GiveawaysManager extends EventEmitter {
             const giveaway = this.giveaways.find((g) => g.messageId === interaction.message.id);
             if (!giveaway || !giveaway.buttons || giveaway.ended) return;
 
+            const replyToInteraction = async (message) => {
+                const embed = giveaway.fillInEmbed(message.embed);
+                await interaction
+                    .reply({
+                        content: giveaway.fillInString(message.content || message),
+                        embeds: embed ? [embed] : null,
+                        components: giveaway.fillInComponents(message.components),
+                        ephemeral: true
+                    })
+                    .catch(() => {});
+            };
+
             if (giveaway.buttons.join.customId === interaction.customId) {
                 // If only one button is used, remove the user if he has already joined
                 if (!giveaway.buttons.leave && giveaway.entrantIds.includes(interaction.member.id)) {
                     const index = giveaway.entrantIds.indexOf(interaction.member.id);
                     giveaway.entrantIds.splice(index, 1);
 
-                    if (giveaway.buttons.leaveReply) {
-                        const embed = giveaway.fillInEmbed(giveaway.buttons.leaveReply.embed);
-                        await interaction
-                            .reply({
-                                content: giveaway.fillInString(
-                                    giveaway.buttons.leaveReply.content || giveaway.buttons.leaveReply
-                                ),
-                                embeds: embed ? [embed] : null,
-                                components: giveaway.fillInComponents(giveaway.buttons.leaveReply.components),
-                                ephemeral: true
-                            })
-                            .catch(() => {});
-                    }
+                    if (giveaway.buttons.leaveReply) await replyToInteraction(giveaway.buttons.leaveReply);
 
                     this.emit('giveawayLeft', giveaway, interaction.member, interaction);
                     return;
@@ -748,19 +748,7 @@ class GiveawaysManager extends EventEmitter {
 
                 giveaway.entrantIds.push(interaction.member.id);
 
-                if (giveaway.buttons.joinReply) {
-                    const embed = giveaway.fillInEmbed(giveaway.buttons.joinReply.embed);
-                    await interaction
-                        .reply({
-                            content: giveaway.fillInString(
-                                giveaway.buttons.joinReply.content || giveaway.buttons.joinReply
-                            ),
-                            embeds: embed ? [embed] : null,
-                            components: giveaway.fillInComponents(giveaway.buttons.joinReply.components),
-                            ephemeral: true
-                        })
-                        .catch(() => {});
-                }
+                if (giveaway.buttons.joinReply) await replyToInteraction(giveaway.buttons.joinReply);
 
                 this.emit('giveawayJoined', giveaway, interaction.member, interaction);
 
@@ -774,19 +762,7 @@ class GiveawaysManager extends EventEmitter {
                 const index = giveaway.entrantIds.indexOf(interaction.member.id);
                 giveaway.entrantIds.splice(index, 1);
 
-                if (giveaway.buttons.leaveReply) {
-                    const embed = giveaway.fillInEmbed(giveaway.buttons.leaveReply.embed);
-                    await interaction
-                        .reply({
-                            content: giveaway.fillInString(
-                                giveaway.buttons.leaveReply.content || giveaway.buttons.leaveReply
-                            ),
-                            embeds: embed ? [embed] : null,
-                            components: giveaway.fillInComponents(giveaway.buttons.leaveReply.components),
-                            ephemeral: true
-                        })
-                        .catch(() => {});
-                }
+                if (giveaway.buttons.leaveReply) await replyToInteraction(giveaway.buttons.leaveReply);
 
                 this.emit('giveawayLeft', giveaway, interaction.member, interaction);
             }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -728,14 +728,14 @@ class GiveawaysManager extends EventEmitter {
                     giveaway.entrantIds.splice(index, 1);
 
                     if (giveaway.buttons.leaveReply) {
-                        const embed = this.fillInEmbed(giveaway.buttons.leaveReply.embed);
+                        const embed = giveaway.fillInEmbed(giveaway.buttons.leaveReply.embed);
                         await interaction
                             .reply({
-                                content: this.fillInString(
+                                content: giveaway.fillInString(
                                     giveaway.buttons.leaveReply.content || giveaway.buttons.leaveReply
                                 ),
                                 embeds: embed ? [embed] : null,
-                                components: this.fillInComponents(giveaway.buttons.leaveReply.components),
+                                components: giveaway.fillInComponents(giveaway.buttons.leaveReply.components),
                                 ephemeral: true
                             })
                             .catch(() => {});
@@ -749,14 +749,14 @@ class GiveawaysManager extends EventEmitter {
                 giveaway.entrantIds.push(interaction.member.id);
 
                 if (giveaway.buttons.joinReply) {
-                    const embed = this.fillInEmbed(giveaway.buttons.joinReply.embed);
+                    const embed = giveaway.fillInEmbed(giveaway.buttons.joinReply.embed);
                     await interaction
                         .reply({
-                            content: this.fillInString(
+                            content: giveaway.fillInString(
                                 giveaway.buttons.joinReply.content || giveaway.buttons.joinReply
                             ),
                             embeds: embed ? [embed] : null,
-                            components: this.fillInComponents(giveaway.buttons.joinReply.components),
+                            components: giveaway.fillInComponents(giveaway.buttons.joinReply.components),
                             ephemeral: true
                         })
                         .catch(() => {});
@@ -775,14 +775,14 @@ class GiveawaysManager extends EventEmitter {
                 giveaway.entrantIds.splice(index, 1);
 
                 if (giveaway.buttons.leaveReply) {
-                    const embed = this.fillInEmbed(giveaway.buttons.leaveReply.embed);
+                    const embed = giveaway.fillInEmbed(giveaway.buttons.leaveReply.embed);
                     await interaction
                         .reply({
-                            content: this.fillInString(
+                            content: giveaway.fillInString(
                                 giveaway.buttons.leaveReply.content || giveaway.buttons.leaveReply
                             ),
                             embeds: embed ? [embed] : null,
-                            components: this.fillInComponents(giveaway.buttons.leaveReply.components),
+                            components: giveaway.fillInComponents(giveaway.buttons.leaveReply.components),
                             ephemeral: true
                         })
                         .catch(() => {});

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,3 +28,14 @@ exports.embedEqual = (embed1, embed2) => {
     }
     return true;
 };
+
+exports.buttonEqual = (button1, button2) => {
+    if (button1.custom_Id !== button2.custom_Id) return false;
+    if (button1.label !== button2.label) return false;
+    if (button1.style !== button2.style) return false;
+    if (button1.emoji?.name !== button2.emoji?.name) return false;
+    if (button1.emoji?.id !== button2.emoji?.id) return false;
+    if (button1.url !== button2.url) return false;
+    if (button1.disabled !== button2.disabled) return false;
+    return true;
+};

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,30 +1,32 @@
 import type { EventEmitter } from 'node:events';
 import type {
+    ActionRowBuilder,
+    APIActionRowComponent,
+    APIButtonComponent,
+    APIEmbed,
+    APIMessageActionRowComponent,
+    APIModalActionRowComponent,
+    Awaitable,
+    ButtonComponent,
     Client,
     Collection,
     ColorResolvable,
+    EmbedBuilder,
     EmojiIdentifierResolvable,
     GuildMember,
+    GuildTextBasedChannel,
+    JSONEncodable,
     Message,
-    ActionRowBuilder,
-    EmbedBuilder,
+    MessageActionRowComponentBuilder,
     MessageMentionOptions,
     MessageReaction,
     PermissionResolvable,
     Snowflake,
-    User,
-    Awaitable,
-    APIEmbed,
-    MessageActionRowComponentBuilder,
-    GuildTextBasedChannel,
-    JSONEncodable,
-    APIActionRowComponent,
-    APIMessageActionRowComponent,
-    APIModalActionRowComponent,
-    APIButtonComponent
+    User
 } from 'discord.js';
 
 export const version: string;
+
 export class GiveawaysManager<ExtraData = any> extends EventEmitter {
     constructor(client: Client, options?: GiveawaysManagerOptions<ExtraData>, init?: boolean);
 
@@ -69,16 +71,19 @@ export class GiveawaysManager<ExtraData = any> extends EventEmitter {
         ...args: GiveawaysManagerEvents<ExtraData>[K]
     ): boolean;
 }
+
 export interface BonusEntry<ExtraData> {
     bonus(member: GuildMember, giveaway: Giveaway<ExtraData>): Awaitable<number>;
     cumulative?: boolean;
 }
+
 export interface LastChanceOptions {
     enabled?: boolean;
     embedColor?: ColorResolvable;
     content?: string;
     threshold?: number;
 }
+
 export interface PauseOptions {
     isPaused?: boolean;
     content?: string;
@@ -87,6 +92,7 @@ export interface PauseOptions {
     durationAfterPause?: number | null;
     infiniteDurationText?: string;
 }
+
 export interface GiveawaysManagerOptions<ExtraData> {
     storage?: string;
     forceUpdateEvery?: number | null;
@@ -102,6 +108,7 @@ export interface GiveawaysManagerOptions<ExtraData> {
         lastChance?: LastChanceOptions;
     };
 }
+
 export interface GiveawayStartOptions<ExtraData> {
     prize: string;
     winnerCount: number;
@@ -124,6 +131,7 @@ export interface GiveawayStartOptions<ExtraData> {
     isDrop?: boolean;
     allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
 }
+
 export interface GiveawayMessages {
     giveaway?: string;
     giveawayEnded?: string;
@@ -139,6 +147,7 @@ export interface GiveawayMessages {
     endedAt?: string;
     hostedBy?: string;
 }
+
 export interface MessageObject {
     content?: string;
     embed?: JSONEncodable<APIEmbed> | APIEmbed;
@@ -148,20 +157,35 @@ export interface MessageObject {
     )[];
     replyToGiveaway?: boolean;
 }
+
 export interface ButtonsObject {
     join: JSONEncodable<APIButtonComponent> | APIButtonComponent;
     leave?: JSONEncodable<APIButtonComponent> | APIButtonComponent;
     joinReply?: string | Omit<MessageObject, 'replyToGiveaway'>;
     leaveReply?: string | Omit<MessageObject, 'replyToGiveaway'>;
 }
+
 export interface GiveawaysManagerEvents<ExtraData = any> {
-    giveawayDeleted: [Giveaway<ExtraData>];
-    giveawayEnded: [Giveaway<ExtraData>, GuildMember[]];
-    giveawayRerolled: [Giveaway<ExtraData>, GuildMember[]];
-    giveawayReactionAdded: [Giveaway<ExtraData>, GuildMember, MessageReaction];
-    giveawayReactionRemoved: [Giveaway<ExtraData>, GuildMember, MessageReaction];
-    endedGiveawayReactionAdded: [Giveaway<ExtraData>, GuildMember, MessageReaction];
+    giveawayDeleted: [giveaway: Giveaway<ExtraData>];
+    giveawayEnded: [giveaway: Giveaway<ExtraData>, member: GuildMember[]];
+    giveawayRerolled: [giveaway: Giveaway<ExtraData>, member: GuildMember[]];
+    giveawayReactionAdded: [
+        giveaway: Giveaway<ExtraData>,
+        member: GuildMember,
+        interaction: MessageReaction | ButtonComponent
+    ];
+    giveawayReactionRemoved: [
+        giveaway: Giveaway<ExtraData>,
+        member: GuildMember,
+        interaction: MessageReaction | ButtonComponent
+    ];
+    endedGiveawayReactionAdded: [
+        giveaway: Giveaway<ExtraData>,
+        member: GuildMember,
+        interaction: MessageReaction | ButtonComponent
+    ];
 }
+
 export class Giveaway<ExtraData = any> extends EventEmitter {
     constructor(manager: GiveawaysManager<ExtraData>, options: GiveawayData<ExtraData>);
 
@@ -231,6 +255,7 @@ export class Giveaway<ExtraData = any> extends EventEmitter {
     public pause(options?: Omit<PauseOptions, 'isPaused' | 'durationAfterPause'>): Promise<Giveaway<ExtraData>>;
     public unpause(): Promise<Giveaway<ExtraData>>;
 }
+
 export interface GiveawayEditOptions<ExtraData> {
     newWinnerCount?: number;
     newPrize?: string;
@@ -245,6 +270,7 @@ export interface GiveawayEditOptions<ExtraData> {
     newExtraData?: ExtraData;
     newLastChance?: LastChanceOptions;
 }
+
 export interface GiveawayRerollOptions {
     winnerCount?: number;
     messages?: {
@@ -253,6 +279,7 @@ export interface GiveawayRerollOptions {
         replyWhenNoWinner?: boolean;
     };
 }
+
 export interface GiveawayData<ExtraData = any> {
     startAt: number;
     endAt: number;
@@ -279,4 +306,13 @@ export interface GiveawayData<ExtraData = any> {
     pauseOptions?: PauseOptions;
     isDrop?: boolean;
     allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
+}
+
+export enum Events {
+    EndedGiveawayReactionAdded = 'endedGiveawayReactionAdded',
+    GiveawayDeleted = 'giveawayDeleted',
+    GiveawayEnded = 'giveawayEnded',
+    GiveawayMemberJoined = 'giveawayMemberJoined',
+    GiveawayMemberLeft = 'giveawayMemberLeft',
+    GiveawayRerolled = 'giveawayRerolled'
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,7 +20,8 @@ import type {
     JSONEncodable,
     APIActionRowComponent,
     APIMessageActionRowComponent,
-    APIModalActionRowComponent
+    APIModalActionRowComponent,
+    APIButtonComponent
 } from 'discord.js';
 
 export const version: string;
@@ -88,15 +89,16 @@ export interface PauseOptions {
 }
 export interface GiveawaysManagerOptions<ExtraData> {
     storage?: string;
-    forceUpdateEvery?: number;
-    endedGiveawaysLifetime?: number;
+    forceUpdateEvery?: number | null;
+    endedGiveawaysLifetime?: number | null;
     default?: {
         botsCanWin?: boolean;
         exemptPermissions?: PermissionResolvable[];
         exemptMembers?: (member: GuildMember, giveaway: Giveaway<ExtraData>) => Awaitable<boolean>;
         embedColor?: ColorResolvable;
         embedColorEnd?: ColorResolvable;
-        reaction?: EmojiIdentifierResolvable;
+        reaction?: EmojiIdentifierResolvable | null;
+        buttons?: ButtonsObject | null;
         lastChance?: LastChanceOptions;
     };
 }
@@ -112,6 +114,7 @@ export interface GiveawayStartOptions<ExtraData> {
     embedColor?: ColorResolvable;
     embedColorEnd?: ColorResolvable;
     reaction?: EmojiIdentifierResolvable;
+    buttons?: ButtonsObject;
     messages?: GiveawayMessages;
     thumbnail?: string;
     image?: string;
@@ -144,6 +147,12 @@ export interface MessageObject {
         | APIActionRowComponent<APIMessageActionRowComponent | APIModalActionRowComponent>
     )[];
     replyToGiveaway?: boolean;
+}
+export interface ButtonsObject {
+    join: JSONEncodable<APIButtonComponent> | APIButtonComponent;
+    leave?: JSONEncodable<APIButtonComponent> | APIButtonComponent;
+    joinReply?: string | Omit<MessageObject, 'replyToGiveaway'>;
+    leaveReply?: string | Omit<MessageObject, 'replyToGiveaway'>;
 }
 export interface GiveawaysManagerEvents<ExtraData = any> {
     giveawayDeleted: [Giveaway<ExtraData>];
@@ -183,7 +192,7 @@ export class Giveaway<ExtraData = any> extends EventEmitter {
     readonly embedColor: ColorResolvable;
     readonly embedColorEnd: ColorResolvable;
     readonly botsCanWin: boolean;
-    readonly reaction: EmojiIdentifierResolvable;
+    readonly reaction: EmojiIdentifierResolvable | null;
     readonly lastChance: Required<LastChanceOptions>;
 
     // getters calculated using other values
@@ -196,8 +205,10 @@ export class Giveaway<ExtraData = any> extends EventEmitter {
     readonly pauseOptions: Required<PauseOptions>;
     readonly isDrop: boolean;
     readonly messageReaction: MessageReaction | null;
+
     private ensureEndTimeout(): void;
     private checkWinnerEntry(user: User): Promise<boolean>;
+
     public checkBonusEntries(user: User): Promise<number>;
     public fetchAllEntrants(): Promise<Collection<Snowflake, User>>;
     public fillInString(string: string): string;
@@ -225,6 +236,7 @@ export interface GiveawayEditOptions<ExtraData> {
     newPrize?: string;
     addTime?: number;
     setEndTimestamp?: number;
+    newButtons?: ButtonsObject;
     newMessages?: GiveawayMessages;
     newThumbnail?: string;
     newImage?: string;
@@ -253,6 +265,7 @@ export interface GiveawayData<ExtraData = any> {
     winnerIds?: Snowflake[];
     messageId: Snowflake;
     reaction?: EmojiIdentifierResolvable;
+    buttons?: ButtonsObject;
     exemptPermissions?: PermissionResolvable[];
     exemptMembers?: string;
     bonusEntries?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -191,25 +191,25 @@ export class Giveaway<ExtraData = any> extends EventEmitter {
 
     public channelId: Snowflake;
     public client: Client;
+    public manager: GiveawaysManager<ExtraData>;
+    public messageId: Snowflake;
+    public guildId: Snowflake;
+    public prize: string;
+    public winnerCount: number;
+    public startAt: number;
     public endAt: number;
     public ended: boolean;
-    public guildId: Snowflake;
-    public hostedBy?: User;
-    public manager: GiveawaysManager<ExtraData>;
     public message: Message | null;
-    public messageId: Snowflake;
+    public hostedBy?: User;
     public messages: Required<GiveawayMessages>;
     public thumbnail?: string;
     public image?: string;
     public extraData?: ExtraData;
     public options: GiveawayData<ExtraData>;
-    public prize: string;
-    public startAt: number;
-    public winnerCount: number;
+    public entrantIds?: Snowflake[];
     public winnerIds: Snowflake[];
     public allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
     private endTimeout?: NodeJS.Timeout;
-    private isEnding?: boolean;
 
     // getters calculated using default manager options
     readonly exemptPermissions: PermissionResolvable[];
@@ -306,6 +306,7 @@ export interface GiveawayData<ExtraData = any> {
     pauseOptions?: PauseOptions;
     isDrop?: boolean;
     allowedMentions?: Omit<MessageMentionOptions, 'repliedUser'>;
+    entrantIds?: Snowflake[];
 }
 
 export enum Events {


### PR DESCRIPTION
## Changes

Adds an option in the default manager or `start()` options to provide a join and optionally a leave button. (if only join is provided, it will also act as leave, if clicked twice)

## Usage test

```js
client.giveawaysManager.start(giveawayChannel, {
   buttons: {
            join: new Discord.ButtonBuilder()
                .setLabel('Join')
                .setStyle(Discord.ButtonStyle.Primary)
                .setCustomId('join'),
            leave: new Discord.ButtonBuilder() // Optional as mentioned
                .setLabel('Leave')
                .setStyle(Discord.ButtonStyle.Secondary)
                .setCustomId('leave')
        }
}
```

## Questions

~~What should happen with `endedGiveawayReactionAdded` ? It was added because some people want to prevent users from joining in case of a reroll. This one would a little bit be the odd one out since it is reaction only, but emitting it for buttons too doesn't really make sense cause of its specific use case.
LMK~~

~~If there should be a 3rd option which takes an array for any other buttons that should get added to the message and should get checked/filled in.
_Tho I have to say thats not a high priority cause that could get added later anyway._
LMK~~

~~The buttons are currently called `join` and `leave`.
I leave it up for debate if they should be called differently, like instead of join --> enter or smth.
LMK~~

~~I currently just named the button events `giveawayJoined` and `giveawayLeft` cause the reaction ones wouldn't really fit.
But so I would like to ask if we should rename the reaction ones to these names too, cause the only event argument difference is `messageReaction` vs `ButtonInteraction`, which can be detected easily via `if (giveaway.buttons)`.
What i also leave open is the event names themselves, it doesn't have to be those I used on a whim.
LMK~~

~~**Important:** Currently the interactions are not deferred, so they just fail.
I did this so the dev can decide in the events on what to do.
But lmk if we should do something by default~~

## Stuff to do

- [X] ~~Proper priority handling of reaction vs button.
Cause it is possible to provide both as the default manager option and then you could set one or the other as `null` in the `start()` options to indicate which default should be used.
But also atm i left it open what to do when a button is provided but it is invalid. Should it automatically default to the reaction and start or reject, or whatever. Vice versa.
_Note: I left some time pass by, so Im not remembering the current behavior/priority stuff completely = the paragraph above is probably worded wrong/describes it falsly but Im too lazy atm to check it again. Still this has to get properly handled._~~
Priority (if I'm not mistaken): `start()-reaction > start()-buttons > default-reaction >  default-buttons`
- [x] Add proper drop compatibility. 
- [X] Document everything properly.
- [x] Better README description (I guess).

## Status

Tested:
* Basic functionality
* Event emitting
* Detecting button changes and editing them.
* Drop compatibility. 

- [x] These changes have been tested and formatted properly.
- [X] This PR introduces some breaking changes.